### PR TITLE
fix: Enable automatic gas calculation

### DIFF
--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -63,7 +63,6 @@ export const storeCode = async ({
         ? new MsgMigrateCode(signer.key.accAddress, codeId, wasmByteCode)
         : new MsgStoreCode(signer.key.accAddress, wasmByteCode),
     ],
-    fee: new Fee(store.fee.gasLimit, store.fee.amount),
   });
 
   const result = await lcd.tx.broadcastSync(storeCodeTx);
@@ -159,7 +158,6 @@ export const instantiate = async ({
         instantiation.instantiateMsg
       ),
     ],
-    fee: new Fee(instantiation.fee.gasLimit, instantiation.fee.amount),
   });
 
   const resInstant = await lcd.tx.broadcast(instantiateTx);
@@ -232,7 +230,6 @@ export const migrate = async ({
         instantiation.instantiateMsg
       ),
     ],
-    fee: new Fee(instantiation.fee.gasLimit, instantiation.fee.amount),
   });
 
   const resInstant = await lcd.tx.broadcast(migrateTx);


### PR DESCRIPTION
When deploying larger contracts it's possible to get out of gas errors. instead of hardcoding these values we can let Terra.js estimate the required gas for us.

This also means there's some outdated gas config values in config.terrain.json, but this is a more urgent issue I'd like to get fixed asap.