### PR TITLE
feat: Use waitForInclusionInBlock for storecode and instantiate.

### DIFF
--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -17,6 +17,7 @@ import {
   setCodeId,
   setContractAddress,
 } from "../config";
+import { waitForInclusionInBlock } from './waitForInclusionBlock';
 import * as fs from "fs-extra";
 import { cli } from "cli-ux";
 import * as YAML from "yaml";
@@ -33,7 +34,6 @@ type StoreCodeParams = {
   codeId?: number;
 };
 export const storeCode = async ({
-  conf,
   noRebuild,
   contract,
   signer,
@@ -55,7 +55,6 @@ export const storeCode = async ({
 
   cli.action.start("storing wasm bytecode on chain");
 
-  const store = conf.store;
   const storeCodeTx = await signer.createAndSignTx({
     msgs: [
       typeof codeId !== "undefined"
@@ -70,21 +69,7 @@ export const storeCode = async ({
     return cli.error(result.raw_log);
   }
 
-  let res;
-  for (let i = 0; i <= 50; i++) {
-    
-    try {
-      res = await lcd.tx.txInfo(result.txhash);
-    } catch (error) {
-      // NOOP
-    }
-
-    if (res) {
-      break;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
+  const res = await waitForInclusionInBlock(lcd, result.txhash);
 
   cli.action.stop()
 
@@ -161,15 +146,16 @@ export const instantiate = async ({
     fee: new Fee(instantiation.fee.gasLimit, instantiation.fee.amount),
   });
 
-  const resInstant = await lcd.tx.broadcast(instantiateTx);
+  const result = await lcd.tx.broadcastSync(instantiateTx);
+  const res = await waitForInclusionInBlock(lcd, result.txhash);
 
   let log = [];
   try {
-    log = JSON.parse(resInstant.raw_log);
+    log = JSON.parse(res.raw_log);
   } catch (error) {
     cli.action.stop();
     if (error instanceof SyntaxError) {
-      cli.error(resInstant.raw_log);
+      cli.error(res.raw_log);
     } else {
       cli.error(`Unexpcted Error: ${error}`);
     }

--- a/src/lib/waitForInclusionBlock.ts
+++ b/src/lib/waitForInclusionBlock.ts
@@ -1,0 +1,19 @@
+
+export const waitForInclusionInBlock = async (lcd, txHash) => {
+  let res;
+  for (let i = 0; i <= 50; i++) {
+    try {
+      res = await lcd.tx.txInfo(txHash);
+    } catch (error) {
+      // NOOP
+    }
+
+    if (res) {
+      break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return res;
+};


### PR DESCRIPTION
We should poll to make sure a transaction makes it in a block before continuing with execution.