### PR TITLE
feat: Add --arm64 flag which will use rust-optimizer-arm64 for optimization. 

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -30,6 +30,10 @@ export default class Deploy extends Command {
     "frontend-refs-path": flags.string({
       default: "./frontend/src/refs.terrain.json",
     }),
+    "arm64": flags.boolean({
+      description: "use rust-optimizer-arm64 for optimization. Not recommended for production, but it will optimize quicker on arm64 hardware during development.",
+      default: false,
+    }),
   };
 
   static args = [{ name: "contract", required: true }];
@@ -54,13 +58,14 @@ export default class Deploy extends Command {
     const sequence = await signer.sequence();
 
     const codeId = await storeCode({
+      lcd,
       conf,
+      signer,
       noRebuild: flags["no-rebuild"],
       contract: args.contract,
-      signer,
       network: flags.network,
       refsPath: flags["refs-path"],
-      lcd: lcd,
+      arm64: flags.arm64,
     });
 
     // pause for account sequence to update.

--- a/src/template/config.terrain.json
+++ b/src/template/config.terrain.json
@@ -1,21 +1,7 @@
 {
   "_global": {
     "_base": {
-      "store": {
-        "fee": {
-          "gasLimit": 2000000,
-          "amount": {
-            "uluna": 1000000
-          }
-        }
-      },
       "instantiation": {
-        "fee": {
-          "gasLimit": 2000000,
-          "amount": {
-            "uluna": 1000000
-          }
-        },
         "instantiateMsg": {
           "count": 0
         }


### PR DESCRIPTION
During the Ottawa hackathon we heard feedback that the deploy process was slow and painful when using m1 hardware. This is due to the emulation used when running rust-optimizer. So we should include a new flag, `--arm64` that will let the developer use `rust-optimizer-arm64` when appropriate, but builds produced should only be used during development. 

From the readme of rust-optimizer: 

> However, the native Arm version produces different wasm artifacts than the Intel version. Given that that impacts reproducibility, non-Intel images and build artifacts contain a "-arm64" suffix, to differentiate and flag them.

> Arm images are released to ease development and testing on Mac M1 machines. For release / production use, only contracts built with the Intel optimizers must be used.