### PR TITLE
fix(docker): manifest path

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -16,7 +16,7 @@ export default class New extends Command {
   static flags = {
     path: flags.string({ description: "path to keep the project" }),
     version: flags.string({
-      default: "0.16",
+      default: "1.0-beta6",
     }),
   };
 


### PR DESCRIPTION
This PR fixes `npx terrain deploy counter --signer validator` due breaking changes related the cosmwasm/rust-optimizer:0.12.3 using cargo 1.55 with the following error log:
```
Building contract in /code ...
 Downloading crates ...
error: failed to download `uint v0.9.3`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/uint-0.9.3/Cargo.toml`

Caused by:
  feature `edition2021` is required
```

The solution is to check the docker image [rust-optimizer:0.12.3](https://hub.docker.com/layers/rust-optimizer/cosmwasm/rust-optimizer/0.12.3/images/sha256-a1b389c185bfa11fb224d2b7faf856f3550753fd895221464644b41cd78c7763?context=explore) (validate that cargo version is 1.55) and upgrade to the [new proposed image has the correct version 1.58.1](https://hub.docker.com/layers/rust-optimizer/cosmwasm/rust-optimizer/0.12.5/images/sha256-c0b7f1e79b3fc82bb49cc6330d804fddfc6c5adc43e83b57acea512318fddda4?context=explore). So in this case I upgraded CosmWasm/rust-optimizer from 0.16 to [1.0-beta6](https://github.com/InterWasm/cw-template/compare/v0.6.0...1.0-beta6#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R39) where the lib is already upgraded.


TBH I don't like this solution because it's a beta version.