### PR TITLE
chord: update rust optimizer

### DIFF
--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -47,7 +47,10 @@ export const storeCode = async ({
 
   if (!noRebuild) {
     execSync("cargo wasm", { stdio: "inherit", env: process.env });
-    execSync("cargo run-script optimize", { stdio: "inherit", env: process.env });
+    execSync(`docker run --rm -v "$(pwd)":/code \
+    --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+    --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+    cosmwasm/rust-optimizer:0.12.5`, { stdio: "inherit", env: process.env });
   }
 
   const wasmByteCode = fs


### PR DESCRIPTION
This PR fix the build process for `npx terrain deploy counter --signer validator` due breaking changes related the [cosmwasm/rust-optimizer:0.12.3](https://hub.docker.com/layers/rust-optimizer/cosmwasm/rust-optimizer/0.12.3/images/sha256-a1b389c185bfa11fb224d2b7faf856f3550753fd895221464644b41cd78c7763?context=explore) using cargo 1.55 with the following error log:
```
Building contract in /code ...
 Downloading crates ...
error: failed to download `uint v0.9.3`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/uint-0.9.3/Cargo.toml`

Caused by:
  feature `edition2021` is required
The solution is to check the docker image rust-optimizer:0.12.3 (validate that cargo version is 1.55) and upgrade to the [new proposed image has the correct version 1.58.1](https://hub.docker.com/layers/rust-optimizer/cosmwasm/rust-optimizer/0.12.5/images/sha256-c0b7f1e79b3fc82bb49cc6330d804fddfc6c5adc43e83b57acea512318fddda4?context=explore). So in this case I upgraded CosmWasm/rust-optimizer from 0.16 to [1.0-beta6](https://github.com/InterWasm/cw-template/compare/v0.6.0...1.0-beta6#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R39) where the lib is already upgraded.
```

Instead of executing the cargo run-script optimize we execute the direct command updating rust-optimizer from 0.12.3 to 0.12.5