### PR TITLE
feat: Append response from LCD if one exists in Error object.

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -2,4 +2,12 @@
 
 require('@oclif/command').run()
     .then(require('@oclif/command/flush'))
-    .catch(require('@oclif/errors/handle'))
+    .catch((error) => {
+        const oclifHandler = require('@oclif/errors/handle');
+        if (error?.response?.data?.message) {
+            // Append the response from LCD.
+            error.message += `\nResponse: ${error?.response?.data?.message}`;
+          
+        }
+        return oclifHandler(error);
+      })


### PR DESCRIPTION
Following the guide here: https://oclif.io/docs/error_handling

I was able to write a global error handler that will append additional information about an error if the error contains a response with a message. 

### Before 

```
using pre-baked 'test1' wallet on localterra as signer
updating contract admin to: terra1dz9kket573z55syas2nw93vkde3mytwx6l64rp... !
    Error: Request failed with status code 400
```

### After 

```
using pre-baked 'test1' wallet on localterra as signer
updating contract admin to: terra1dz9kket573z55syas2nw93vkde3mytwx6l64rp... !
    Error: Request failed with status code 400
    Response: failed to execute message; message index: 0: unauthorized: invalid request
```

Notice the extra `Response:` which provides necessary info for debugging. 