### PR TITLE
feat: New contract:updateAdmin command.

### DIFF
--- a/src/commands/contract/updateAdmin.ts
+++ b/src/commands/contract/updateAdmin.ts
@@ -1,0 +1,64 @@
+import { Command, flags } from "@oclif/command";
+import * as YAML from "yaml";
+import { LCDClient, MsgUpdateContractAdmin } from "@terra-money/terra.js";
+import { cli } from "cli-ux";
+import { loadConnections, loadRefs } from "../../config";
+import { getSigner } from "../../lib/signer";
+import { waitForInclusionInBlock } from '../../lib/waitForInclusionBlock';
+
+
+export default class ContractUpdateAdmin extends Command {
+  static description = "Update the admin of a contract.";
+
+  static flags = {
+    network: flags.string({ default: "localterra" }),
+    "config-path": flags.string({ default: "./config.terrain.json" }),
+    "refs-path": flags.string({ default: "./refs.terrain.json" }),
+    "keys-path": flags.string({ default: "./keys.terrain.js" }),
+    "instance-id": flags.string({ default: "default" }),
+    signer: flags.string({ required: true }),
+  };
+
+  static args = [
+    { name: "contract", required: true },
+    { name: "admin", required: true },
+  ];
+
+  async run() {
+    const { args, flags } = this.parse(ContractUpdateAdmin);
+
+    const connections = loadConnections(flags["config-path"]);
+    const refs = loadRefs(flags["refs-path"]);
+    const network = flags.network;
+    const lcd = new LCDClient(connections(flags.network));
+    const signer = getSigner({
+      network: flags.network,
+      signerId: flags.signer,
+      keysPath: flags["keys-path"],
+      lcd,
+    });
+
+    const contractAddress = refs[network][args.contract].contractAddresses[flags['instance-id']];
+
+    cli.action.start(
+      `updating contract admin to: ${args.admin}`
+    );
+
+    const updateAdminTx = await signer.createAndSignTx({
+      msgs: [
+        new MsgUpdateContractAdmin(
+          signer.key.accAddress,
+          args.admin,
+          contractAddress
+        ),
+      ],
+    });
+
+    const result = await lcd.tx.broadcastSync(updateAdminTx);
+    const res = await waitForInclusionInBlock(lcd, result.txhash);
+
+    cli.action.stop();
+
+    cli.log(YAML.stringify(JSON.parse(res.raw_log)));
+  }
+}


### PR DESCRIPTION
New command to update the admin of an already deployed contract. 

This is useful for moving ownership of a contract to a new multisig wallet. 

## Usage

First deploy your contract, make sure you use `--set-signer-as-admin` to set an admin address for the contract. 

```
> terrain deploy cw20-blocklist --signer test1 --set-signer-as-admin
```

Then you can update the admin to a new address: 

```
> terrain contract:updateAdmin cw20-blocklist terra1dz9kket573z55syas2nw93vkde3mytwx6l64rp --signer test1
using pre-baked 'test1' wallet on localterra as signer
updating contract admin to: terra1dz9kket573z55syas2nw93vkde3mytwx6l64rp... done
- events:
    - type: message
      attributes:
        - key: action
          value: /terra.wasm.v1beta1.MsgUpdateContractAdmin
        - key: module
          value: wasm
    - type: update_contract_admin
      attributes:
        - key: admin
          value: terra1dz9kket573z55syas2nw93vkde3mytwx6l64rp
        - key: contract_address
          value: terra1qdjkagz8q35c79rzwx27n2xwd6m69tjj8253ya
```