### PR TITLE
feat: add wallet:new command

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ USAGE
 * [`terrain task:new [TASK]`](#terrain-tasknew-task)
 * [`terrain task:run [TASK]`](#terrain-taskrun-task)
 * [`terrain test CONTRACT-NAME`](#terrain-test-contract-name)
+* [`terrain wallet:new`](#terrain-wallet-new)
 
 ## `terrain code:new [NAME]`
 
@@ -692,6 +693,24 @@ EXAMPLES
 ```
 
 _See code: [src/commands/test.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/test.ts)_
+
+## `terrain wallet:new`
+
+Generate a new wallet to use for signing contracts
+```
+USAGE
+  $ terrain wallet:new [--outfile <value>]
+
+FLAGS
+  --index=<value>    key index to use, default value is 0
+  --outfile=<value>  absolute path to store the mnemonic key to. If omitted, output to stdout
+
+DESCRIPTION
+  Generate a new wallet.
+```
+
+_See code: [src/commands/task/run.ts](./src/commands/wallet/new.ts)_
+
 <!-- commandsstop -->
 
 

--- a/src/commands/wallet/new.ts
+++ b/src/commands/wallet/new.ts
@@ -1,0 +1,41 @@
+import { Command, flags } from '@oclif/command';
+import { MnemonicKey } from '@terra-money/terra.js';
+import * as fs from 'fs';
+
+export default class WalletNew extends Command {
+  static description = 'Generate a new wallet.';
+
+  static flags = {
+    outfile: flags.string({
+      description: 'absolute path to store the mnemonic key to. If omitted, output to stdout',
+    }),
+    index: flags.integer({
+      description: 'key index to use, default value is 0',
+      default: 0,
+    }),
+  };
+
+  async run() {
+    const { flags } = this.parse(WalletNew);
+    this.log('Generating new terra-wallet');
+
+    const mk = new MnemonicKey({
+      index: flags.index,
+    });
+    if (flags.outfile) {
+      if (fs.existsSync(flags.outfile)) {
+        this.error(`outfile: '${flags.outfile}' already exists, abort`);
+        this.exit(1);
+      }
+
+      this.log(`saving mnemonic to '${flags.outfile}'`);
+      fs.writeFileSync(flags.outfile, mk.mnemonic);
+      this.exit(0);
+    }
+
+    this.log('mnemonic key:');
+    this.log(mk.mnemonic);
+
+    this.exit(0);
+  }
+}


### PR DESCRIPTION
This PR will:

- Add `wallet:new` command for generating new terra wallets

It outputs to `stdout` by default, but it can be given the flag `--outfile=<path>` to store the mnemonic there instead.

Close #39 