### PR TITLE
fix: typo cargo.toml -> Cargo.toml

### DIFF
--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -45,9 +45,9 @@ export const storeCode = async ({
   arm64,
 }: StoreCodeParams) => {
   process.chdir(`contracts/${contract}`);
-  const { package: pkg } = parse(fs.readFileSync('./cargo.toml', 'utf-8'));
+  const { package: pkg } = parse(fs.readFileSync('./Cargo.toml', 'utf-8'));
   if (contract !== pkg.name) {
-    cli.error(`Change the package name in cargo.toml to ${contract} to build`);
+    cli.error(`Change the package name in Cargo.toml to ${contract} to build`);
   }
   
   if (!noRebuild) {


### PR DESCRIPTION
On deployment the following script tries to access "cargo.toml" instead of "Cargo.toml" which produces the following error:

$ terrain deploy token-factory --signer test --network testnet
    Error: ENOENT: no such file or directory, open './cargo.toml'
Changing the file name to uppercase is the solution for this error