### PR TITLE
feat: Automate deployments through tasks! 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,7 @@ module.exports = {
     '@typescript-eslint',
   ],
   rules: {
+    'import/extensions': 0,
+    'import/no-unresolved': 0,
   },
 };

--- a/README.md
+++ b/README.md
@@ -328,13 +328,63 @@ task(async ({ wallets, refs, config, client }) => {
 });
 ```
 
+As of Terrain 0.3.0 it is possible to deploy and instantiate contracts from tasks. This can be useful for multi-contract, or multi-stage deployments. 
+
+```js
+const { task } = require("@terra-money/terrain");
+
+task(async ({ wallets, client, deploy }) => {
+  // First deploy the counter smart contract.
+  const counterCodeId = await deploy.storeCode(wallets.test1, "counter");
+  const counterAddress = await deploy.instantiate(
+    // Signer
+    wallets.test1,
+    // Contract name
+    "counter",
+    // Code ID
+    counterCodeId,
+    // Instance ID
+    "default",
+    // Contract admin
+    wallets.test1.key.accAddress
+  );
+
+  // Now deploy a CW20 with the counter contract set as the minter in instantiation.
+  const cw20CodeId = await deploy.storeCode(wallets.test1, "cw20-base");
+  const cw20Address = await deploy.instantiate(
+    wallets.test1,
+    "cw20-base",
+    cw20CodeId,
+    "default",
+    wallets.test1.key.accAddress,
+    // Custom instantiation message.
+    // with no message provided the default from config.terrain will be used.
+    {
+      name: "counter",
+      symbol: "CTR",
+      decimals: 6,
+      initial_balances: [],
+      mint: {
+        minter: counterAddress,
+      },
+    }
+  );
+
+  // Update the CW20 address in counter.
+  // Note: It's important to use the address returned by deploy.instantiate
+  // Refs are only read into memory at the start of the task.
+  await client.execute(wallets.test1, counterAddress, {
+    update_token: { token: cw20Address },
+  });
+
+  console.log(`CW20 Address: ${cw20Address}`);
+});
+```
 ---
 
 # Migrating CosmWasm Contracts on Terra
 
-(Thanks to @octalmage)
-
-On Terra, it is possible to initilize contracts as **_migratable_**. A migratable contract allows an adminstrator to upload a new version of a contract and then send a migrate message to move to the new code.
+On Terra it is possible to initilize contracts as migratable. This functionallity allows the adminstrator to upload a new version of the contract, then send a migrate message to move to the new code.
 
 <a href="https://docs.terra.money/docs/develop/dapp/quick-start/contract-migration.html" target="_blank">This tutorial</a> builds on top of the Terrain Quick Start Guide and walks you through a contract migration.
 
@@ -393,6 +443,29 @@ To use the main branch of the Terrain repo on your local machine, do the followi
 
 1. Clone the repo.
 
+<!-- usage -->
+```sh-session
+$ npm install -g @terra-money/terrain
+$ terrain COMMAND
+running command...
+$ terrain (-v|--version|version)
+@terra-money/terrain/0.2.0 darwin-x64 node-v16.9.1
+$ terrain --help [COMMAND]
+USAGE
+  $ terrain COMMAND
+...
+```
+<!-- usagestop -->
+```sh-session
+$ npm install -g @terra-money/terrain
+$ terrain COMMAND
+running command...
+$ terrain (-v|--version|version)
+@terra-money/terrain/0.2.0 darwin-x64 node-v16.9.1
+$ terrain --help [COMMAND]
+USAGE
+  $ terrain COMMAND
+...
 ```
 git clone --branch main --depth 1 https://github.com/terra-money/terrain
 ```
@@ -426,6 +499,8 @@ npm unlink terrain
 # Terrain Commands
 
 <!-- commands -->
+* [`terrain code:new NAME`](#terrain-codenew-name)
+* [`terrain code:store CONTRACT`](#terrain-codestore-contract)
 * [`terrain console`](#terrain-console)
 * [`terrain contract:instantiate CONTRACT`](#terrain-contractinstantiate-contract)
 * [`terrain contract:migrate [CONTRACT]`](#terrain-contractmigrate-contract)
@@ -441,6 +516,48 @@ npm unlink terrain
 * [`terrain test CONTRACT-NAME`](#terrain-test-contract-name)
 * [`terrain test:coverage [CONTRACT-NAME]`](#terrain-testcoverage-contract-name)
 * [`terrain wallet:new`](#terrain-walletnew)
+
+## `terrain code:new NAME`
+
+Generate new contract.
+
+```
+USAGE
+  $ terrain code:new [NAME] [--path <value>] [--version <value>]
+
+FLAGS
+  --path=<value>     [default: ./contracts] path to keep the contracts
+  --version=<value>  [default: 0.16]
+
+DESCRIPTION
+  Generate new contract.
+```
+
+_See code: [src/commands/code/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/code/new.ts)_
+
+## `terrain code:store CONTRACT`
+
+Store code on chain.
+
+```
+USAGE
+  $ terrain code:store [CONTRACT] [--signer <value>] [--no-rebuild] [--network <value>] [--config-path <value>]
+    [--refs-path <value>] [--keys-path <value>] [--code-id <value>]
+
+FLAGS
+  --code-id=<value>
+  --config-path=<value>  [default: ./config.terrain.json]
+  --keys-path=<value>    [default: ./keys.terrain.js]
+  --network=<value>      [default: localterra]
+  --no-rebuild           deploy the wasm bytecode as is.
+  --refs-path=<value>    [default: ./refs.terrain.json]
+  --signer=<value>       [default: test1]
+
+DESCRIPTION
+  Store code on chain.
+```
+
+_See code: [src/commands/code/store.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/code/store.ts)_
 
 ## `terrain console`
 
@@ -461,7 +578,7 @@ DESCRIPTION
   contracts.
 ```
 
-_See code: [src/commands/console.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/console.ts)_
+_See code: [src/commands/console.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/console.ts)_
 
 ## `terrain contract:instantiate CONTRACT`
 
@@ -469,24 +586,24 @@ Instantiate the contract.
 
 ```
 USAGE
-  $ terrain contract:instantiate [CONTRACT] --signer <value> [--network <value>] [--config-path <value>] [--refs-path
-    <value>] [--keys-path <value>] [--instance-id <value>] [--code-id <value>] [--set-signer-as-admin]
+  $ terrain contract:instantiate [CONTRACT] [--signer <value>] [--set-signer-as-admin] [--network <value>] [--config-path
+    <value>] [--refs-path <value>] [--keys-path <value>] [--instance-id <value>] [--code-id <value>]
 
 FLAGS
-  --code-id=<value>      target code id for migration, can do only once after columbus-5 upgrade
+  --code-id=<value>      specfic codeId to instantiate
   --config-path=<value>  [default: ./config.terrain.json]
   --instance-id=<value>  [default: default]
   --keys-path=<value>    [default: ./keys.terrain.js]
   --network=<value>      [default: localterra]
   --refs-path=<value>    [default: ./refs.terrain.json]
-  --set-signer-as-admin
-  --signer=<value>       (required)
+  --set-signer-as-admin  set signer (deployer) as admin to allow migration.
+  --signer=<value>       [default: test1]
 
 DESCRIPTION
   Instantiate the contract.
 ```
 
-_See code: [src/commands/contract/instantiate.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/instantiate.ts)_
+_See code: [src/commands/contract/instantiate.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/contract/instantiate.ts)_
 
 ## `terrain contract:migrate [CONTRACT]`
 
@@ -494,7 +611,7 @@ Migrate the contract.
 
 ```
 USAGE
-  $ terrain contract:migrate [CONTRACT] --signer <value> [--no-rebuild] [--network <value>] [--config-path <value>]
+  $ terrain contract:migrate [CONTRACT] [--signer <value>] [--no-rebuild] [--network <value>] [--config-path <value>]
     [--refs-path <value>] [--keys-path <value>] [--instance-id <value>] [--code-id <value>] [--arm64]
 
 FLAGS
@@ -507,63 +624,13 @@ FLAGS
   --network=<value>      [default: localterra]
   --no-rebuild           deploy the wasm bytecode as is.
   --refs-path=<value>    [default: ./refs.terrain.json]
-  --signer=<value>       (required)
+  --signer=<value>       [default: test1]
 
 DESCRIPTION
   Migrate the contract.
 ```
 
-_See code: [src/commands/contract/migrate.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/migrate.ts)_
-
-## `terrain contract:new NAME`
-
-Generate new contract.
-
-```
-USAGE
-  $ terrain contract:new [NAME] [--path <value>] [--version <value>] [--authors <value>]
-
-FLAGS
-  --authors=<value>  [default: Terra Money <core@terra.money>]
-  --path=<value>     [default: ./contracts] path to keep the contracts
-  --version=<value>  [default: 1.0-beta6]
-
-DESCRIPTION
-  Generate new contract.
-
-EXAMPLES
-  $ terrain code:new awesome_contract
-
-  $ terrain code:new awesome_contract --path path/to/dapp
-
-  $ terrain code:new awesome_contract --path path/to/dapp --authors "ExampleAuthor<example@email.domain>"
-```
-
-_See code: [src/commands/contract/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/new.ts)_
-
-## `terrain contract:store CONTRACT`
-
-Store code on chain.
-
-```
-USAGE
-  $ terrain contract:store [CONTRACT] --signer <value> [--no-rebuild] [--network <value>] [--config-path <value>]
-    [--refs-path <value>] [--keys-path <value>] [--code-id <value>]
-
-FLAGS
-  --code-id=<value>
-  --config-path=<value>  [default: ./config.terrain.json]
-  --keys-path=<value>    [default: ./keys.terrain.js]
-  --network=<value>      [default: localterra]
-  --no-rebuild
-  --refs-path=<value>    [default: ./refs.terrain.json]
-  --signer=<value>       (required)
-
-DESCRIPTION
-  Store code on chain.
-```
-
-_See code: [src/commands/contract/store.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/store.ts)_
+_See code: [src/commands/contract/migrate.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/contract/migrate.ts)_
 
 ## `terrain contract:updateAdmin CONTRACT ADMIN`
 
@@ -571,7 +638,7 @@ Update the admin of a contract.
 
 ```
 USAGE
-  $ terrain contract:updateAdmin [CONTRACT] [ADMIN] --signer <value> [--network <value>] [--config-path <value>]
+  $ terrain contract:updateAdmin [CONTRACT] [ADMIN] [--signer <value>] [--network <value>] [--config-path <value>]
     [--refs-path <value>] [--keys-path <value>] [--instance-id <value>]
 
 FLAGS
@@ -580,13 +647,13 @@ FLAGS
   --keys-path=<value>    [default: ./keys.terrain.js]
   --network=<value>      [default: localterra]
   --refs-path=<value>    [default: ./refs.terrain.json]
-  --signer=<value>       (required)
+  --signer=<value>       [default: test1]
 
 DESCRIPTION
   Update the admin of a contract.
 ```
 
-_See code: [src/commands/contract/updateAdmin.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/updateAdmin.ts)_
+_See code: [src/commands/contract/updateAdmin.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/contract/updateAdmin.ts)_
 
 ## `terrain deploy CONTRACT`
 
@@ -594,9 +661,9 @@ Build wasm bytecode, store code on chain and instantiate.
 
 ```
 USAGE
-  $ terrain deploy [CONTRACT] --signer <value> [--no-rebuild] [--network <value>] [--config-path <value>]
-    [--refs-path <value>] [--keys-path <value>] [--instance-id <value>] [--set-signer-as-admin] [--admin-address
-    <value>] [--frontend-refs-path <value>] [--arm64]
+  $ terrain deploy [CONTRACT] [--signer <value>] [--arm64] [--no-rebuild] [--set-signer-as-admin] [--network
+    <value>] [--config-path <value>] [--refs-path <value>] [--keys-path <value>] [--instance-id <value>]
+    [--admin-address <value>] [--frontend-refs-path <value>]
 
 FLAGS
   --admin-address=<value>       set custom address as contract admin to allow migration.
@@ -604,19 +671,19 @@ FLAGS
                                 optimize quicker on arm64 hardware during development.
   --config-path=<value>         [default: ./config.terrain.json]
   --frontend-refs-path=<value>  [default: ./frontend/src/refs.terrain.json]
-  --instance-id=<value>         [default: default]
+  --instance-id=<value>         [default: default] enable management of multiple instances of the same contract
   --keys-path=<value>           [default: ./keys.terrain.js]
   --network=<value>             [default: localterra]
   --no-rebuild                  deploy the wasm bytecode as is.
   --refs-path=<value>           [default: ./refs.terrain.json]
   --set-signer-as-admin         set signer (deployer) as admin to allow migration.
-  --signer=<value>              (required)
+  --signer=<value>              [default: test1]
 
 DESCRIPTION
   Build wasm bytecode, store code on chain and instantiate.
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/deploy.ts)_
 
 ## `terrain help [COMMAND]`
 
@@ -668,7 +735,7 @@ EXAMPLES
   $ terrain new awesome-dapp --path path/to/dapp --framework vue --authors "ExampleAuthor<example@email.domain>"
 ```
 
-_See code: [src/commands/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/new.ts)_
+_See code: [src/commands/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/new.ts)_
 
 ## `terrain sync-refs [FILE]`
 
@@ -686,7 +753,7 @@ DESCRIPTION
   Sync configuration with frontend app.
 ```
 
-_See code: [src/commands/sync-refs.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/sync-refs.ts)_
+_See code: [src/commands/sync-refs.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/sync-refs.ts)_
 
 ## `terrain task:new [TASK]`
 
@@ -700,7 +767,7 @@ DESCRIPTION
   create new task
 ```
 
-_See code: [src/commands/task/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/task/new.ts)_
+_See code: [src/commands/task/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/task/new.ts)_
 
 ## `terrain task:run [TASK]`
 
@@ -721,7 +788,7 @@ DESCRIPTION
   run predefined task
 ```
 
-_See code: [src/commands/task/run.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/task/run.ts)_
+_See code: [src/commands/task/run.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/task/run.ts)_
 
 ## `terrain test CONTRACT-NAME`
 
@@ -743,30 +810,11 @@ EXAMPLES
   $ terrain test counter --no-fail-fast
 ```
 
-_See code: [src/commands/test.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/test.ts)_
-
-## `terrain test:coverage [CONTRACT-NAME]`
-
-Runs unit tests for a contract directory.
-
-```
-USAGE
-  $ terrain test:coverage [CONTRACT-NAME]
-
-DESCRIPTION
-  Runs unit tests for a contract directory.
-
-EXAMPLES
-  $ terrain test:coverage
-
-  $ terrain test:coverage counter
-```
-
-_See code: [src/commands/test/coverage.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/test/coverage.ts)_
+_See code: [src/commands/test.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/test.ts)_
 
 ## `terrain wallet:new`
 
-Generate a new wallet.
+Generate a new wallet to use for signing contracts
 
 ```
 USAGE
@@ -777,8 +825,8 @@ FLAGS
   --outfile=<value>  absolute path to store the mnemonic key to. If omitted, output to stdout
 
 DESCRIPTION
-  Generate a new wallet.
+  Generate a new wallet to use for signing contracts
 ```
 
-_See code: [src/commands/wallet/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/wallet/new.ts)_
+_See code: [src/commands/wallet/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/wallet/new.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ task(async ({ wallets, refs, config, client }) => {
 });
 ```
 
-As of Terrain 0.3.0 it is possible to deploy and instantiate contracts from tasks. This can be useful for multi-contract, or multi-stage deployments. 
+As of Terrain 0.4.0 it is possible to deploy and instantiate contracts from tasks. This can be useful for multi-contract, or multi-stage deployments. 
 
 ```js
 const { task } = require("@terra-money/terrain");
@@ -384,7 +384,7 @@ task(async ({ wallets, client, deploy }) => {
 
 # Migrating CosmWasm Contracts on Terra
 
-On Terra it is possible to initilize contracts as migratable. This functionallity allows the adminstrator to upload a new version of the contract, then send a migrate message to move to the new code.
+On Terra it is possible to initalize contracts as migratable. This functionallity allows the adminstrator to upload a new version of the contract, then send a migrate message to move to the new code.
 
 <a href="https://docs.terra.money/docs/develop/dapp/quick-start/contract-migration.html" target="_blank">This tutorial</a> builds on top of the Terrain Quick Start Guide and walks you through a contract migration.
 
@@ -443,29 +443,6 @@ To use the main branch of the Terrain repo on your local machine, do the followi
 
 1. Clone the repo.
 
-<!-- usage -->
-```sh-session
-$ npm install -g @terra-money/terrain
-$ terrain COMMAND
-running command...
-$ terrain (-v|--version|version)
-@terra-money/terrain/0.2.0 darwin-x64 node-v16.9.1
-$ terrain --help [COMMAND]
-USAGE
-  $ terrain COMMAND
-...
-```
-<!-- usagestop -->
-```sh-session
-$ npm install -g @terra-money/terrain
-$ terrain COMMAND
-running command...
-$ terrain (-v|--version|version)
-@terra-money/terrain/0.2.0 darwin-x64 node-v16.9.1
-$ terrain --help [COMMAND]
-USAGE
-  $ terrain COMMAND
-...
 ```
 git clone --branch main --depth 1 https://github.com/terra-money/terrain
 ```

--- a/README.md
+++ b/README.md
@@ -476,11 +476,9 @@ npm unlink terrain
 # Terrain Commands
 
 <!-- commands -->
-* [`terrain code:new NAME`](#terrain-codenew-name)
-* [`terrain code:store CONTRACT`](#terrain-codestore-contract)
 * [`terrain console`](#terrain-console)
 * [`terrain contract:instantiate CONTRACT`](#terrain-contractinstantiate-contract)
-* [`terrain contract:migrate [CONTRACT]`](#terrain-contractmigrate-contract)
+* [`terrain contract:migrate CONTRACT`](#terrain-contractmigrate-contract)
 * [`terrain contract:new NAME`](#terrain-contractnew-name)
 * [`terrain contract:store CONTRACT`](#terrain-contractstore-contract)
 * [`terrain contract:updateAdmin CONTRACT ADMIN`](#terrain-contractupdateadmin-contract-admin)
@@ -493,48 +491,6 @@ npm unlink terrain
 * [`terrain test CONTRACT-NAME`](#terrain-test-contract-name)
 * [`terrain test:coverage [CONTRACT-NAME]`](#terrain-testcoverage-contract-name)
 * [`terrain wallet:new`](#terrain-walletnew)
-
-## `terrain code:new NAME`
-
-Generate new contract.
-
-```
-USAGE
-  $ terrain code:new [NAME] [--path <value>] [--version <value>]
-
-FLAGS
-  --path=<value>     [default: ./contracts] path to keep the contracts
-  --version=<value>  [default: 0.16]
-
-DESCRIPTION
-  Generate new contract.
-```
-
-_See code: [src/commands/code/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/code/new.ts)_
-
-## `terrain code:store CONTRACT`
-
-Store code on chain.
-
-```
-USAGE
-  $ terrain code:store [CONTRACT] [--signer <value>] [--no-rebuild] [--network <value>] [--config-path <value>]
-    [--refs-path <value>] [--keys-path <value>] [--code-id <value>]
-
-FLAGS
-  --code-id=<value>
-  --config-path=<value>  [default: ./config.terrain.json]
-  --keys-path=<value>    [default: ./keys.terrain.js]
-  --network=<value>      [default: localterra]
-  --no-rebuild           deploy the wasm bytecode as is.
-  --refs-path=<value>    [default: ./refs.terrain.json]
-  --signer=<value>       [default: test1]
-
-DESCRIPTION
-  Store code on chain.
-```
-
-_See code: [src/commands/code/store.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/code/store.ts)_
 
 ## `terrain console`
 
@@ -555,7 +511,7 @@ DESCRIPTION
   contracts.
 ```
 
-_See code: [src/commands/console.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/console.ts)_
+_See code: [src/commands/console.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/console.ts)_
 
 ## `terrain contract:instantiate CONTRACT`
 
@@ -580,9 +536,9 @@ DESCRIPTION
   Instantiate the contract.
 ```
 
-_See code: [src/commands/contract/instantiate.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/contract/instantiate.ts)_
+_See code: [src/commands/contract/instantiate.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/instantiate.ts)_
 
-## `terrain contract:migrate [CONTRACT]`
+## `terrain contract:migrate CONTRACT`
 
 Migrate the contract.
 
@@ -607,7 +563,57 @@ DESCRIPTION
   Migrate the contract.
 ```
 
-_See code: [src/commands/contract/migrate.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/contract/migrate.ts)_
+_See code: [src/commands/contract/migrate.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/migrate.ts)_
+
+## `terrain contract:new NAME`
+
+Generate new contract.
+
+```
+USAGE
+  $ terrain contract:new [NAME] [--path <value>] [--version <value>] [--authors <value>]
+
+FLAGS
+  --authors=<value>  [default: Terra Money <core@terra.money>]
+  --path=<value>     [default: ./contracts] path to keep the contracts
+  --version=<value>  [default: 1.0-beta6]
+
+DESCRIPTION
+  Generate new contract.
+
+EXAMPLES
+  $ terrain code:new awesome_contract
+
+  $ terrain code:new awesome_contract --path path/to/dapp
+
+  $ terrain code:new awesome_contract --path path/to/dapp --authors "ExampleAuthor<example@email.domain>"
+```
+
+_See code: [src/commands/contract/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/new.ts)_
+
+## `terrain contract:store CONTRACT`
+
+Store code on chain.
+
+```
+USAGE
+  $ terrain contract:store [CONTRACT] [--signer <value>] [--no-rebuild] [--network <value>] [--config-path <value>]
+    [--refs-path <value>] [--keys-path <value>] [--code-id <value>]
+
+FLAGS
+  --code-id=<value>
+  --config-path=<value>  [default: ./config.terrain.json]
+  --keys-path=<value>    [default: ./keys.terrain.js]
+  --network=<value>      [default: localterra]
+  --no-rebuild           deploy the wasm bytecode as is.
+  --refs-path=<value>    [default: ./refs.terrain.json]
+  --signer=<value>       [default: test1]
+
+DESCRIPTION
+  Store code on chain.
+```
+
+_See code: [src/commands/contract/store.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/store.ts)_
 
 ## `terrain contract:updateAdmin CONTRACT ADMIN`
 
@@ -630,7 +636,7 @@ DESCRIPTION
   Update the admin of a contract.
 ```
 
-_See code: [src/commands/contract/updateAdmin.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/contract/updateAdmin.ts)_
+_See code: [src/commands/contract/updateAdmin.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/contract/updateAdmin.ts)_
 
 ## `terrain deploy CONTRACT`
 
@@ -660,7 +666,7 @@ DESCRIPTION
   Build wasm bytecode, store code on chain and instantiate.
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/deploy.ts)_
 
 ## `terrain help [COMMAND]`
 
@@ -712,7 +718,7 @@ EXAMPLES
   $ terrain new awesome-dapp --path path/to/dapp --framework vue --authors "ExampleAuthor<example@email.domain>"
 ```
 
-_See code: [src/commands/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/new.ts)_
+_See code: [src/commands/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/new.ts)_
 
 ## `terrain sync-refs [FILE]`
 
@@ -730,7 +736,7 @@ DESCRIPTION
   Sync configuration with frontend app.
 ```
 
-_See code: [src/commands/sync-refs.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/sync-refs.ts)_
+_See code: [src/commands/sync-refs.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/sync-refs.ts)_
 
 ## `terrain task:new [TASK]`
 
@@ -744,7 +750,7 @@ DESCRIPTION
   create new task
 ```
 
-_See code: [src/commands/task/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/task/new.ts)_
+_See code: [src/commands/task/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/task/new.ts)_
 
 ## `terrain task:run [TASK]`
 
@@ -765,7 +771,7 @@ DESCRIPTION
   run predefined task
 ```
 
-_See code: [src/commands/task/run.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/task/run.ts)_
+_See code: [src/commands/task/run.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/task/run.ts)_
 
 ## `terrain test CONTRACT-NAME`
 
@@ -787,7 +793,26 @@ EXAMPLES
   $ terrain test counter --no-fail-fast
 ```
 
-_See code: [src/commands/test.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/test.ts)_
+_See code: [src/commands/test.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/test.ts)_
+
+## `terrain test:coverage [CONTRACT-NAME]`
+
+Runs unit tests for a contract directory.
+
+```
+USAGE
+  $ terrain test:coverage [CONTRACT-NAME]
+
+DESCRIPTION
+  Runs unit tests for a contract directory.
+
+EXAMPLES
+  $ terrain test:coverage
+
+  $ terrain test:coverage counter
+```
+
+_See code: [src/commands/test/coverage.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/test/coverage.ts)_
 
 ## `terrain wallet:new`
 
@@ -805,5 +830,5 @@ DESCRIPTION
   Generate a new wallet to use for signing contracts
 ```
 
-_See code: [src/commands/wallet/new.ts](https://github.com/terra-money/terrain/blob/v0.2.0/src/commands/wallet/new.ts)_
+_See code: [src/commands/wallet/new.ts](https://github.com/terra-money/terrain/blob/v0.3.1/src/commands/wallet/new.ts)_
 <!-- commandsstop -->

--- a/src/commands/contract/instantiate.ts
+++ b/src/commands/contract/instantiate.ts
@@ -3,22 +3,23 @@ import { LCDClient } from '@terra-money/terra.js';
 import { loadConfig, loadConnections, loadRefs } from '../../config';
 import { instantiate } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
+import * as flag from '../../lib/flag';
 
 export default class ContractInstantiate extends Command {
   static description = 'Instantiate the contract.';
 
   static flags = {
+    signer: flag.signer,
+    'set-signer-as-admin': flag.setSignerAsAdmin,
     network: flags.string({ default: 'localterra' }),
     'config-path': flags.string({ default: './config.terrain.json' }),
     'refs-path': flags.string({ default: './refs.terrain.json' }),
     'keys-path': flags.string({ default: './keys.terrain.js' }),
     'instance-id': flags.string({ default: 'default' }),
-    signer: flags.string({ required: true }),
     'code-id': flags.integer({
       description:
-        'target code id for migration, can do only once after columbus-5 upgrade',
+        'specfic codeId to instantiate',
     }),
-    'set-signer-as-admin': flags.boolean({ default: false }),
   };
 
   static args = [{ name: 'contract', required: true }];

--- a/src/commands/contract/migrate.ts
+++ b/src/commands/contract/migrate.ts
@@ -3,21 +3,19 @@ import { LCDClient } from '@terra-money/terra.js';
 import { loadConfig, loadConnections } from '../../config';
 import { migrate, storeCode } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
+import * as flag from '../../lib/flag';
 
 export default class ContractMigrate extends Command {
   static description = 'Migrate the contract.';
 
   static flags = {
-    'no-rebuild': flags.boolean({
-      description: 'deploy the wasm bytecode as is.',
-      default: false,
-    }),
+    signer: flag.signer,
+    'no-rebuild': flag.noRebuild,
     network: flags.string({ default: 'localterra' }),
     'config-path': flags.string({ default: './config.terrain.json' }),
     'refs-path': flags.string({ default: './refs.terrain.json' }),
     'keys-path': flags.string({ default: './keys.terrain.js' }),
     'instance-id': flags.string({ default: 'default' }),
-    signer: flags.string({ required: true }),
     'code-id': flags.integer({
       description:
         'target code id for migration',

--- a/src/commands/contract/store.ts
+++ b/src/commands/contract/store.ts
@@ -3,18 +3,19 @@ import { LCDClient } from '@terra-money/terra.js';
 import { loadConfig, loadConnections } from '../../config';
 import { storeCode } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
+import * as flag from '../../lib/flag';
 
 export default class CodeStore extends Command {
   static description = 'Store code on chain.';
 
   static flags = {
-    'no-rebuild': flags.boolean({ default: false }),
+    signer: flag.signer,
+    'no-rebuild': flag.noRebuild,
     network: flags.string({ default: 'localterra' }),
     'config-path': flags.string({ default: './config.terrain.json' }),
     'refs-path': flags.string({ default: './refs.terrain.json' }),
     'keys-path': flags.string({ default: './keys.terrain.js' }),
     'code-id': flags.integer({}),
-    signer: flags.string({ required: true }),
   };
 
   static args = [{ name: 'contract', required: true }];

--- a/src/commands/contract/updateAdmin.ts
+++ b/src/commands/contract/updateAdmin.ts
@@ -4,6 +4,7 @@ import { LCDClient, MsgUpdateContractAdmin } from "@terra-money/terra.js";
 import { cli } from "cli-ux";
 import { loadConnections, loadRefs } from "../../config";
 import { getSigner } from "../../lib/signer";
+import * as flag from '../../lib/flag';
 import { waitForInclusionInBlock } from '../../lib/waitForInclusionBlock';
 
 
@@ -11,12 +12,12 @@ export default class ContractUpdateAdmin extends Command {
   static description = "Update the admin of a contract.";
 
   static flags = {
+    signer: flag.signer,
     network: flags.string({ default: "localterra" }),
     "config-path": flags.string({ default: "./config.terrain.json" }),
     "refs-path": flags.string({ default: "./refs.terrain.json" }),
     "keys-path": flags.string({ default: "./keys.terrain.js" }),
     "instance-id": flags.string({ default: "default" }),
-    signer: flags.string({ required: true }),
   };
 
   static args = [

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -4,34 +4,26 @@ import * as fs from 'fs';
 import { loadConfig, loadConnections } from '../config';
 import { instantiate, storeCode } from '../lib/deployment';
 import { getSigner } from '../lib/signer';
+import * as flag from '../lib/flag';
 
 export default class Deploy extends Command {
   static description = 'Build wasm bytecode, store code on chain and instantiate.';
 
   static flags = {
-    'no-rebuild': flags.boolean({
-      description: 'deploy the wasm bytecode as is.',
-      default: false,
-    }),
+    signer: flag.signer,
+    arm64: flag.arm64,
+    'no-rebuild': flag.noRebuild,
+    'set-signer-as-admin': flag.setSignerAsAdmin,
     network: flags.string({ default: 'localterra' }),
     'config-path': flags.string({ default: './config.terrain.json' }),
     'refs-path': flags.string({ default: './refs.terrain.json' }),
     'keys-path': flags.string({ default: './keys.terrain.js' }),
-    'instance-id': flags.string({ default: 'default' }),
-    signer: flags.string({ required: true }),
-    'set-signer-as-admin': flags.boolean({
-      description: 'set signer (deployer) as admin to allow migration.',
-      default: false,
-    }),
+    'instance-id': flag.instanceId,
     'admin-address': flags.string({
       description: 'set custom address as contract admin to allow migration.',
     }),
     'frontend-refs-path': flags.string({
       default: './frontend/src/refs.terrain.json',
-    }),
-    arm64: flags.boolean({
-      description: 'use rust-optimizer-arm64 for optimization. Not recommended for production, but it will optimize quicker on arm64 hardware during development.',
-      default: false,
     }),
   };
 

--- a/src/commands/task/run.ts
+++ b/src/commands/task/run.ts
@@ -64,7 +64,6 @@ export default class Run extends Command {
   }
 }
 
-
 function runScript(
   scriptPath: string,
   env: {

--- a/src/commands/wallet/new.ts
+++ b/src/commands/wallet/new.ts
@@ -3,7 +3,7 @@ import { MnemonicKey } from '@terra-money/terra.js';
 import * as fs from 'fs';
 
 export default class WalletNew extends Command {
-  static description = 'Generate a new wallet.';
+  static description = 'Generate a new wallet to use for signing contracts';
 
   static flags = {
     outfile: flags.string({

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ export type InstantiateMessage = Record<string, any>;
 
 export type ContractConfig = {
   // TODO: Remove since fee in config is deprecated.
+  /**
+ * @deprecated The property should not be used
+ */
   store?: { fee: Fee };
   instantiation: {
     // TODO: Remove since fee in config is deprecated.

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,10 @@ export type ContractConfig = {
  */
   store?: { fee: Fee };
   instantiation: {
-    // TODO: Remove since fee in config is deprecated.
+  // TODO: Remove since fee in config is deprecated.
+  /**
+ * @deprecated The property should not be used
+ */
     fee?: Fee;
     instantiateMsg: InstantiateMessage;
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,10 +11,10 @@ type Fee = {
 export type InstantiateMessage = Record<string, any>;
 
 export type ContractConfig = {
-  // TODO: Remove since fee in config is deprecated. 
+  // TODO: Remove since fee in config is deprecated.
   store?: { fee: Fee };
   instantiation: {
-    // TODO: Remove since fee in config is deprecated. 
+    // TODO: Remove since fee in config is deprecated.
     fee?: Fee;
     instantiateMsg: InstantiateMessage;
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,11 +8,15 @@ type Fee = {
   amount: { [coin: string]: number };
 };
 
+export type InstantiateMessage = Record<string, any>;
+
 export type ContractConfig = {
-  store: { fee: Fee };
+  // TODO: Remove since fee in config is deprecated. 
+  store?: { fee: Fee };
   instantiation: {
-    fee: Fee;
-    instantiateMsg: Record<string, any>;
+    // TODO: Remove since fee in config is deprecated. 
+    fee?: Fee;
+    instantiateMsg: InstantiateMessage;
   };
 };
 

--- a/src/lib/LCDClientExtra.ts
+++ b/src/lib/LCDClientExtra.ts
@@ -36,13 +36,14 @@ export class LCDClientExtra extends LCDClient {
     const msgs = [
       new MsgExecuteContract(
         wallet.key.accAddress,
-        this.refs[contract].contractAddresses[instanceId],
+        // Enable supplying a contract address instead of the contract name.
+        contract.startsWith('terra1') ? contract : this.refs[contract].contractAddresses[instanceId],
         msg,
         coins,
       ),
     ];
-    const _options = options ? { ...options, msgs } : { msgs };
-    const tx = await wallet.createAndSignTx(_options);
-    return await this.tx.broadcast(tx);
+    const mergedOptions = options ? { ...options, msgs } : { msgs };
+    const tx = await wallet.createAndSignTx(mergedOptions);
+    return this.tx.broadcast(tx);
   }
 }

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -33,6 +33,7 @@ type StoreCodeParams = {
   codeId?: number;
   arm64?: boolean;
 };
+
 export const storeCode = async ({
   noRebuild,
   contract,
@@ -187,8 +188,9 @@ export const instantiate = async ({
   }
 
   cli.action.stop();
-  const contractAddress = log[0].events
-    .find((event: { type: string }) => event.type === 'instantiate')
+
+  const contractAddress: string = log[0].events
+    .find((event: { type: string }) => event.type === 'instantiate_contract')
     .attributes.find(
       (attr: { key: string }) => attr.key === '_contract_address',
     ).value;
@@ -202,6 +204,8 @@ export const instantiate = async ({
   saveRefs(updatedRefs, refsPath);
 
   cli.log(YAML.stringify(log));
+
+  return contractAddress;
 };
 
 type MigrateParams = {

--- a/src/lib/flag.ts
+++ b/src/lib/flag.ts
@@ -1,0 +1,20 @@
+import { flags } from '@oclif/command';
+
+export const signer = flags.string({ default: 'test1' });
+
+export const noRebuild = flags.boolean({
+  description: 'deploy the wasm bytecode as is.',
+  default: false,
+});
+
+export const arm64 = flags.boolean({
+  description: 'use rust-optimizer-arm64 for optimization. Not recommended for production, but it will optimize quicker on arm64 hardware during development.',
+  default: false,
+});
+
+export const setSignerAsAdmin = flags.boolean({
+  description: 'set signer (deployer) as admin to allow migration.',
+  default: false,
+});
+
+export const instanceId = flags.string({ default: 'default', description: 'enable management of multiple instances of the same contract' });


### PR DESCRIPTION
This PR includes a few features/improvements.

1. The ability to call storeCode and instantiate from inside of tasks. I've added an example to the readme which can be viewed here: https://github.com/terra-money/terrain/blob/de5627172ec60da427c7abd5ae6721fa60051087/README.md#creating-tasks
2. Moving reused flags to `src/lib/flag.ts`. There were situations where flags are reused, but the description or default was different depending on the command. In these situations we can move the flag to this new file, import it, and reference the same default value and description.
3. Added a default value for `--signer`. When using LocalTerra, we can assume the signer will be the `test1` wallet. This improves usability for local development. 
4. I ran the readme generator which overwrote some of the work by @terran6. If we do want to modify the oclif readme template we should do without manual tweaks to the readme, because they get reverted. 
5. Small tweaks and cleanup based on eslint rules.  

