### PR TITLE
fix: Make contract argument required for migrate command.

### DIFF
--- a/src/commands/contract/migrate.ts
+++ b/src/commands/contract/migrate.ts
@@ -28,7 +28,7 @@ export default class ContractMigrate extends Command {
     }),
   };
 
-  static args = [{ name: 'contract' }];
+  static args = [{ name: 'contract', required: true }];
 
   async run() {
     const { args, flags } = this.parse(ContractMigrate);


### PR DESCRIPTION
Migrate won't work without a contract supplied: 

```
 terrain contract:migrate --signer pisco --network testnet   
    Error: ENOENT: no such file or directory, chdir '~/GitHub/terra-dapp' -> 'contracts/undefined'
    Code: ENOENT
  ```

After: 

```
terrain contract:migrate --signer pisco --network testnet  
 ›   Error: Missing 1 required arg:
 ›   contract
 ›   See more help with --help
```