### PR TITLE
fix(instantiate): new contract

### DIFF
--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -190,7 +190,7 @@ export const instantiate = async ({
   cli.action.stop();
 
   const contractAddress: string = log[0].events
-    .find((event: { type: string }) => event.type === 'instantiate_contract')
+    .find((event: { type: string }) => event.type === 'instantiate')
     .attributes.find(
       (attr: { key: string }) => attr.key === '_contract_address',
     ).value;


### PR DESCRIPTION
Since the new version of the chain renamed the event with instantiate when recovering the contract address we also should do the same with terrain otherwise the deployment flow fails with the following error code:

```
instantiating contract with code id: 1... done
    TypeError: Cannot read properties of undefined (reading 'attributes')
```

![image](https://user-images.githubusercontent.com/49301655/173373580-a938102f-f702-4861-8992-7057769d20ce.png)
