### PR TITLE
fix: Use transpile-only when running tasks.

### DIFF
--- a/src/commands/task/run.ts
+++ b/src/commands/task/run.ts
@@ -82,14 +82,15 @@ function runScript(
   // keep track of whether callback has been invoked to prevent multiple invocations
   let invoked = false;
 
-  const cProcess = childProcess.fork(scriptPath,
+  const cProcess = childProcess.fork(
+    scriptPath,
     {
       env: {
         ...process.env,
-        ...env
+        ...env,
       },
-      execArgv: ['-r', 'ts-node/register']
-    }
+      execArgv: ['-r', 'ts-node/register/transpile-only'],
+    },
   );
 
   // listen for errors as they may prevent the exit event from firing


### PR DESCRIPTION
As pointed out in #100 the current version of Terrain is too strict on the tasks. Registering the ts-node project with transpile-only focuses on just converting the code to JavaScript which seems more appropriate. 

Closes #100