### PR TITLE
fix: Generated clients should use PascalCase.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@terra-money/template-scaffolding": "1.0.1",
         "@terra-money/terra.js": "^3.1.0",
         "adm-zip": "^0.5.9",
+        "case": "^1.6.3",
         "chalk": "^4.0.0",
         "cli-ux": "^5.6.3",
         "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@terra-money/template-scaffolding": "1.0.1",
     "@terra-money/terra.js": "^3.1.0",
     "adm-zip": "^0.5.9",
+    "case": "^1.6.3",
     "chalk": "^4.0.0",
     "cli-ux": "^5.6.3",
     "fs-extra": "^8.1.0",

--- a/src/commands/contract/generateClient.ts
+++ b/src/commands/contract/generateClient.ts
@@ -2,7 +2,7 @@ import { Command, flags } from '@oclif/command';
 import { cli } from 'cli-ux';
 import { execSync } from 'child_process';
 import * as fs from 'fs-extra';
-import capitalize from '../../lib/capitalize';
+import { pascal } from 'case';
 import TerrainCLI from '../../TerrainCLI';
 import generateClient from '../../lib/generateClient';
 
@@ -34,10 +34,10 @@ export default class GenerateClient extends Command {
     }
 
     cli.action.start(
-      `generating ${capitalize(args.contract)}Client.ts`,
+      `generating ${pascal(args.contract)}Client.ts`,
     );
 
-    await generateClient(capitalize(args.contract), `./contracts/${args.contract}/schema`, `${flags['lib-path']}/clients`);
+    await generateClient(pascal(args.contract), `./contracts/${args.contract}/schema`, `${flags['lib-path']}/clients`);
 
     cli.action.stop();
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,7 +3,7 @@ import { TemplateScaffolding } from '@terra-money/template-scaffolding';
 import cli from 'cli-ux';
 import * as path from 'path';
 import * as fs from 'fs';
-import capitalize from '../lib/capitalize';
+import { pascal } from 'case';
 
 export default class New extends Command {
   static description = 'Create new dapp from template.';
@@ -44,7 +44,7 @@ export default class New extends Command {
 
     const templateEntries = {
       'project-name': args.name,
-      'client-name': `${capitalize(args.name)}Client`,
+      'client-name': `${pascal(args.name)}Client`,
       crate_name: args.name,
       authors: flags.authors,
       ' "now" | date: "%Y" ': `${new Date().getFullYear()}`,

--- a/src/lib/capitalize.ts
+++ b/src/lib/capitalize.ts
@@ -1,1 +1,0 @@
-export default (s: string) => s && s[0].toUpperCase() + s.slice(1);


### PR DESCRIPTION
While running through the tutorial for Terrain in our docs I ran into the following error: 

```
➜  my_terra_dapp terrain console
    Error: Cannot find module './clients/My_terra_dappClient'
```

Turns out just capitalizing wasn't enough, it needs to be PascalCase to remove underscores. After these changes everything is running smooth: 

```
➜ terrain console
terrain > await lib.increment();
{
  txhash: '00F29472EE973B678F3CC23A26751C4B7B45E3CE7D2973AE78E6A328B362278A',
  raw_log: '[{"events":[{"type":"execute","attributes":[{"key":"_contract_address","value":"terra1n234trhxyj4ze95td2t5ngdpyqd8529urm54epum3aqg3205pcasg0g5pu"}]},{"type":"message","attributes":[{"key":"action","value":"/cosmwasm.wasm.v1.MsgExecuteContract"},{"key":"module","value":"wasm"},{"key":"sender","value":"terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v"}]},{"type":"wasm","attributes":[{"key":"_contract_address","value":"terra1n234trhxyj4ze95td2t5ngdpyqd8529urm54epum3aqg3205pcasg0g5pu"},{"key":"method","value":"try_increment"}]}]}]',
  gas_wanted: 197972,
  gas_used: 127644,
  height: 3013,
  logs: [
    TxLog {
      msg_index: 0,
      log: '',
      events: [Array],
      eventsByType: [Object]
    }
  ],
  code: 0,
  codespace: '',
  timestamp: '2022-07-14T19:32:06Z'
}
```