### PR TITLE
feat:default-admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,16 +397,13 @@ Now instead of running `terrain task:run deploy_counter` you can run `terrain de
 
 # Migrating CosmWasm Contracts on Terra
 
-On Terra it is possible to initalize contracts as migratable. This functionallity allows the adminstrator to upload a new version of the contract, then send a migrate message to move to the new code.
+On Terra, it is possible to initialize a contract as migratable. This functionallity allows the adminstrator to upload a new version of the contract and then send a migrate message to move to the new code.
 
-<a href="https://docs.terra.money/docs/develop/dapp/quick-start/contract-migration.html" target="_blank">This tutorial</a> builds on top of the Terrain Quick Start Guide and walks you through a contract migration.
+The <a href="https://docs.terra.money/docs/develop/dapp/quick-start/contract-migration.html" target="_blank">contract migration tutorial</a> builds on top of the Terrain Quick Start Guide and walks you through a contract migration.
 
 ## Adding MigrateMsg to the Contract
 
-In order for a contract to be migratable, it must satisfy the following two requirements:
-
-1. The smart contract handles the `MigrateMsg` transaction.
-2. The smart contract has an admininstrator set.
+In order for a contract to be migratable, it must be able to handle a `MigrateMsg` transaction.
 
 To implement support for `MigrateMsg`, add the message to the `msg.rs` file. To do so, navigate to `msg.rs` and place the following code just above the `InstantiateMsg` struct.
 
@@ -432,18 +429,22 @@ pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Respons
 
 ## Migrating the Contract
 
-In the previous Terrain tutorial, we deployed the contract, but did not initialize it as migratable.
-
-After adding MigrateMsg to the smart contract, we can redeploy the contract and add the `--set-signer-as-admin` flag. This allows the transaction signer to migrate the contract in the future.
+Adding the MigrateMsg to the smart contract allows the contract's administrator to migrate the contract in the future.  When we deploy our contract, the wallet address of the signer will be automatically designated as the contract administrator.  In the following command, the contract is deployed with the preconfigured LocalTerra `test1` wallet as the signer and administrator of our counter contract. 
 
 ```sh
-terrain deploy counter --signer test1 --set-signer-as-admin
+terrain deploy counter --signer test1
 ```
 
 If you decide to make changes to the deployed contract, you can migrate to the updated code by executing the following command.
 
 ```sh
 terrain contract:migrate counter --signer test1
+```
+
+If you would like to specify the address of the desired administrator for your smart contract, you may utilize the `--admin-address` flag in the deploy command followed by the wallet address of the desired administrator.
+
+```sh
+terrain deploy counter --signer test1 --admin-address <insert-admin-wallet-address>
 ```
 
 # Use Terrain Main Branch Locally
@@ -573,7 +574,7 @@ Instantiate the contract.
 
 ```
 USAGE
-  $ terrain contract:instantiate [CONTRACT] [--signer <value>] [--network <value>] [--set-signer-as-admin] [--instance-id
+  $ terrain contract:instantiate [CONTRACT] [--signer <value>] [--network <value>] [--instance-id
     <value>] [--code-id <value>] [--config-path <value>] [--refs-path <value>] [--keys-path <value>]
 
 FLAGS
@@ -583,7 +584,6 @@ FLAGS
   --keys-path=<value>    [default: ./keys.terrain.js]
   --network=<value>      [default: localterra] network to deploy to from config.terrain.json
   --refs-path=<value>    [default: ./refs.terrain.json]
-  --set-signer-as-admin  set signer (deployer) as admin to allow migration.
   --signer=<value>       [default: test1]
 
 DESCRIPTION
@@ -713,7 +713,7 @@ Build wasm bytecode, store code on chain and instantiate.
 
 ```
 USAGE
-  $ terrain deploy [CONTRACT] [--signer <value>] [--network <value>] [--no-rebuild] [--set-signer-as-admin]
+  $ terrain deploy [CONTRACT] [--signer <value>] [--network <value>] [--no-rebuild]
     [--instance-id <value>] [--frontend-refs-path <value>] [--admin-address <value>] [--no-sync <value>] [--config-path
     <value>] [--refs-path <value>] [--keys-path <value>]
 
@@ -727,7 +727,6 @@ FLAGS
   --no-rebuild                  deploy the wasm bytecode as is.
   --no-sync=<value>             don't attempt to sync contract refs to frontend.
   --refs-path=<value>           [default: ./refs.terrain.json]
-  --set-signer-as-admin         set signer (deployer) as admin to allow migration.
   --signer=<value>              [default: test1]
 
 DESCRIPTION

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@oclif/plugin-not-found": "^2.3.1",
         "@octalmage/terra-cosmwasm-typescript-gen": "^0.1.1",
         "@terra-money/template-scaffolding": "1.0.1",
-        "@terra-money/terra.js": "^3.1.0",
+        "@terra-money/terra.js": "^3.1.5",
         "adm-zip": "^0.5.9",
         "boxen": "^5.1.2",
         "case": "^1.6.3",
@@ -2144,6 +2144,7 @@
     },
     "node_modules/@improbable-eng/grpc-web": {
       "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.14.1.tgz",
       "integrity": "sha512-XaIYuunepPxoiGVLLHmlnVminUGzBTnXr8Wv7khzmLWbNw4TCwJKX09GSMJlKhu/TRk6gms0ySFxewaETSBqgw==",
       "dependencies": {
         "browser-headers": "^0.4.1"
@@ -3176,11 +3177,12 @@
       }
     },
     "node_modules/@terra-money/terra.js": {
-      "version": "3.1.0",
-      "integrity": "sha512-5OvH4vx1zGvlgtV1ABbhvZ+l74DEXq+xV5KJLKUG7DK6Sj7+ellZNCJTlxaF0LGYaYU3gZp3Cfvl+73YsKLU+A==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.1.5.tgz",
+      "integrity": "sha512-oggJGqNdi3xpDhZoNb49fLmNkl1oXy9wF6GnIRcirOiNdh90Q0CYA7YFMBMzutYg7TR1cyrUSKmKq0oq6Tz+UQ==",
       "dependencies": {
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-        "@terra-money/terra.proto": "^0.2.0-beta.4",
+        "@terra-money/terra.proto": "^2.1.0",
         "axios": "^0.26.1",
         "bech32": "^2.0.0",
         "bip32": "^2.0.6",
@@ -3199,8 +3201,9 @@
       }
     },
     "node_modules/@terra-money/terra.proto": {
-      "version": "0.2.0-beta.4",
-      "integrity": "sha512-ALwIOpiZgpELvUO27+Lgc4qQz6k5NB58YsUHX2Bf7gocspShRftps5kjj/bovZs/M6AO4J7Qj07QJRBekMinMA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-2.1.0.tgz",
+      "integrity": "sha512-rhaMslv3Rkr+QsTQEZs64FKA4QlfO0DfQHaR6yct/EovenMkibDEQ63dEL6yJA6LCaEQGYhyVB9JO9pTUA8ybw==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.14.1",
         "google-protobuf": "^3.17.3",
@@ -4201,6 +4204,7 @@
     },
     "node_modules/browser-headers": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
       "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
     },
     "node_modules/browser-process-hrtime": {
@@ -11882,6 +11886,7 @@
     },
     "@improbable-eng/grpc-web": {
       "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.14.1.tgz",
       "integrity": "sha512-XaIYuunepPxoiGVLLHmlnVminUGzBTnXr8Wv7khzmLWbNw4TCwJKX09GSMJlKhu/TRk6gms0ySFxewaETSBqgw==",
       "requires": {
         "browser-headers": "^0.4.1"
@@ -12707,11 +12712,12 @@
       }
     },
     "@terra-money/terra.js": {
-      "version": "3.1.0",
-      "integrity": "sha512-5OvH4vx1zGvlgtV1ABbhvZ+l74DEXq+xV5KJLKUG7DK6Sj7+ellZNCJTlxaF0LGYaYU3gZp3Cfvl+73YsKLU+A==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.1.5.tgz",
+      "integrity": "sha512-oggJGqNdi3xpDhZoNb49fLmNkl1oXy9wF6GnIRcirOiNdh90Q0CYA7YFMBMzutYg7TR1cyrUSKmKq0oq6Tz+UQ==",
       "requires": {
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-        "@terra-money/terra.proto": "^0.2.0-beta.4",
+        "@terra-money/terra.proto": "^2.1.0",
         "axios": "^0.26.1",
         "bech32": "^2.0.0",
         "bip32": "^2.0.6",
@@ -12727,8 +12733,9 @@
       }
     },
     "@terra-money/terra.proto": {
-      "version": "0.2.0-beta.4",
-      "integrity": "sha512-ALwIOpiZgpELvUO27+Lgc4qQz6k5NB58YsUHX2Bf7gocspShRftps5kjj/bovZs/M6AO4J7Qj07QJRBekMinMA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-2.1.0.tgz",
+      "integrity": "sha512-rhaMslv3Rkr+QsTQEZs64FKA4QlfO0DfQHaR6yct/EovenMkibDEQ63dEL6yJA6LCaEQGYhyVB9JO9pTUA8ybw==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.14.1",
         "google-protobuf": "^3.17.3",
@@ -13482,6 +13489,7 @@
     },
     "browser-headers": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
       "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@oclif/plugin-not-found": "^2.3.1",
     "@octalmage/terra-cosmwasm-typescript-gen": "^0.1.1",
     "@terra-money/template-scaffolding": "1.0.1",
-    "@terra-money/terra.js": "^3.1.0",
+    "@terra-money/terra.js": "^3.1.5",
     "adm-zip": "^0.5.9",
     "boxen": "^5.1.2",
     "case": "^1.6.3",

--- a/src/commands/contract/instantiate.ts
+++ b/src/commands/contract/instantiate.ts
@@ -11,7 +11,6 @@ export default class ContractInstantiate extends Command {
   static flags = {
     signer: flag.signer,
     network: flag.network,
-    'set-signer-as-admin': flag.setSignerAsAdmin,
     'instance-id': flags.string({ default: 'default' }),
     'code-id': flags.integer({
       description:
@@ -38,9 +37,7 @@ export default class ContractInstantiate extends Command {
       lcd,
     });
 
-    const admin = flags['set-signer-as-admin']
-      ? signer.key.accAddress
-      : undefined;
+    const admin = signer.key.accAddress;
 
     await instantiate({
       conf,

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -12,7 +12,6 @@ export default class Deploy extends Command {
     signer: flag.signer,
     network: flag.network,
     'no-rebuild': flag.noRebuild,
-    'set-signer-as-admin': flag.setSignerAsAdmin,
     'instance-id': flag.instanceId,
     'frontend-refs-path': flag.frontendRefsPath,
     'admin-address': flags.string({
@@ -76,9 +75,9 @@ export default class Deploy extends Command {
       // eslint-disable-next-line no-promise-executor-return
       await new Promise((r) => setTimeout(r, 1000));
 
-      const admin = flags['set-signer-as-admin']
-        ? signer.key.accAddress
-        : flags['admin-address'];
+      const admin = flags['admin-address']
+        ? flags['admin-address']
+        : signer.key.accAddress;
 
       await instantiate({
         conf,

--- a/src/lib/flag.ts
+++ b/src/lib/flag.ts
@@ -7,11 +7,6 @@ export const noRebuild = flags.boolean({
   default: false,
 });
 
-export const setSignerAsAdmin = flags.boolean({
-  description: 'set signer (deployer) as admin to allow migration.',
-  default: false,
-});
-
 export const instanceId = flags.string({ default: 'default', description: 'enable management of multiple instances of the same contract' });
 
 export const network = flags.string({ default: 'localterra', description: 'network to deploy to from config.terrain.json' });


### PR DESCRIPTION
Allowing for the signer of a deploy or instantiate command to be the default admin of the contract.  Removed the --set-signer-as-admin flag and updated README accordingly.