### PR TITLE
fix: TerrainCLI.error()

### DIFF
--- a/src/TerrainCLI.ts
+++ b/src/TerrainCLI.ts
@@ -77,6 +77,7 @@ class TerrainCLI {
     cli.log(
       `\n${this.prefix} ${this.errorStyle(`Error: ${errorMsg}`)}\n`,
     );
+    process.exit();
   }
 
   // await TerrainCLI.anykey(anykeyMsg) styling.

--- a/src/commands/sync-refs.ts
+++ b/src/commands/sync-refs.ts
@@ -1,7 +1,9 @@
 import { Command } from '@oclif/command';
+import * as path from 'path';
 import { cli } from 'cli-ux';
 import * as fs from 'fs-extra';
 import { refsPath, frontendRefsPath } from '../lib/flag';
+import TerrainCLI from '../TerrainCLI';
 
 export default class SyncRefs extends Command {
   static description = 'Sync configuration with frontend app.';
@@ -15,17 +17,17 @@ export default class SyncRefs extends Command {
     const { flags } = this.parse(SyncRefs);
 
     if (!fs.pathExistsSync(flags.dest)) {
-      cli.error('destination directory not found, not syncing refs');
+      TerrainCLI.error(`Failed to sync refs. Destination directory '${flags.dest}' not found.`);
     }
 
-    // fs.copyFileSync requires the full path to copy to so lets
-    // append "refs.terrain.json" if it doesn't exist.
+    // Append "refs.terrain.json" to flags.dest path if file unavailable.
+    // The fs.copyFileSync command requires the full file path.
     const destFullPath = flags.dest.endsWith('refs.terrain.json')
       ? flags.dest
-      : `${flags.dest.replace(/\/$/, '')}/refs.terrain.json`;
+      : path.join(flags.dest, 'refs.terrain.json');
 
     cli.action.start(
-      `syncing refs from '${flags['refs-path']}' to '${destFullPath}'`,
+      `Syncing refs from '${flags['refs-path']}' to '${destFullPath}'`,
     );
 
     fs.copyFileSync(flags['refs-path'], destFullPath);

--- a/src/commands/task/new.ts
+++ b/src/commands/task/new.ts
@@ -14,7 +14,7 @@ export default class TaskNew extends Command {
 
     const pathToTasks = path.join(process.cwd(), 'tasks', `${args.task}.ts`);
     if (fs.existsSync(pathToTasks)) {
-      TerrainCLI.error(`Task with name ${args.task} already exists chose another name for the task.`);
+      TerrainCLI.error(`A task with the name ${args.task} already exists. Try using another name for the task.`);
     }
 
     cli.action.start(`Creating task: ${args.task}`);

--- a/src/commands/task/new.ts
+++ b/src/commands/task/new.ts
@@ -14,8 +14,7 @@ export default class TaskNew extends Command {
 
     const pathToTasks = path.join(process.cwd(), 'tasks', `${args.task}.ts`);
     if (fs.existsSync(pathToTasks)) {
-      TerrainCLI.error(`Task with name ${args.task} already exists chose another name for the task`);
-      return process.exit();
+      TerrainCLI.error(`Task with name ${args.task} already exists chose another name for the task.`);
     }
 
     cli.action.start(`Creating task: ${args.task}`);

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -51,7 +51,6 @@ export default class Test extends Command {
         TerrainCLI.error(
           `Contract '${args['contract-name']}' not available in contracts directory.`,
         );
-        process.exit();
       }
 
       // If contracts directory does not exist in current directory, step back one directory.


### PR DESCRIPTION
Adding process.exit() command to TerrainCLI.error() and removing instances of the two commands being used sequentially.

Utilizing path.join() to combine paths in sync-refs in place of template literal.