### PR TITLE
feat: run terrain:contract commands anywhere

### DIFF
--- a/src/commands/contract/build.ts
+++ b/src/commands/contract/build.ts
@@ -1,6 +1,10 @@
 import { Command } from '@oclif/command';
+import { join } from 'path';
+import { existsSync } from 'fs';
 import { build } from '../../lib/deployment';
 import * as flag from '../../lib/flag';
+import TerrainCLI from '../../TerrainCLI';
+import runCommand from '../../lib/runCommand';
 
 export default class Build extends Command {
   static description = 'Build wasm bytecode.';
@@ -14,8 +18,30 @@ export default class Build extends Command {
   async run() {
     const { args } = this.parse(Build);
 
-    await build({
-      contract: args.contract,
-    });
+    // Command execution path.
+    const execPath = join('contracts', args.contract);
+
+    // Command to be performed.
+    const command = async () => {
+      await build({
+        contract: args.contract,
+      });
+    };
+
+    // Error check to be performed upon each backtrack iteration.
+    const errorCheck = () => {
+      if (existsSync('contracts') && !existsSync(execPath)) {
+        TerrainCLI.error(
+          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+        );
+      }
+    };
+
+    // Attempt to execute command while backtracking through file tree.
+    await runCommand(
+      execPath,
+      command,
+      errorCheck,
+    );
   }
 }

--- a/src/commands/contract/instantiate.ts
+++ b/src/commands/contract/instantiate.ts
@@ -1,9 +1,13 @@
 import { Command, flags } from '@oclif/command';
 import { LCDClient } from '@terra-money/terra.js';
+import { join } from 'path';
+import { existsSync } from 'fs';
 import { loadConfig, loadConnections } from '../../config';
 import { instantiate } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
 import * as flag from '../../lib/flag';
+import TerrainCLI from '../../TerrainCLI';
+import runCommand from '../../lib/runCommand';
 
 export default class ContractInstantiate extends Command {
   static description = 'Instantiate the contract.';
@@ -24,30 +28,52 @@ export default class ContractInstantiate extends Command {
   async run() {
     const { args, flags } = this.parse(ContractInstantiate);
 
-    const connections = loadConnections(flags['config-path']);
-    const config = loadConfig(flags['config-path']);
-    const conf = config(flags.network, args.contract);
+    // Command execution path.
+    const execPath = flags['config-path'];
 
-    const lcd = new LCDClient(connections(flags.network));
-    const signer = await getSigner({
-      network: flags.network,
-      signerId: flags.signer,
-      keysPath: flags['keys-path'],
-      lcd,
-    });
+    // Command to be performed.
+    const command = async () => {
+      const connections = loadConnections(flags['config-path']);
+      const config = loadConfig(flags['config-path']);
+      const conf = config(flags.network, args.contract);
 
-    const admin = signer.key.accAddress;
+      const lcd = new LCDClient(connections(flags.network));
+      const signer = await getSigner({
+        network: flags.network,
+        signerId: flags.signer,
+        keysPath: flags['keys-path'],
+        lcd,
+      });
 
-    await instantiate({
-      conf,
-      signer,
-      admin,
-      contract: args.contract,
-      codeId: flags['code-id'],
-      network: flags.network,
-      instanceId: flags['instance-id'],
-      refsPath: flags['refs-path'],
-      lcd,
-    });
+      const admin = signer.key.accAddress;
+
+      await instantiate({
+        conf,
+        signer,
+        admin,
+        contract: args.contract,
+        codeId: flags['code-id'],
+        network: flags.network,
+        instanceId: flags['instance-id'],
+        refsPath: flags['refs-path'],
+        lcd,
+      });
+    };
+
+    // Error check to be performed upon each backtrack iteration.
+    const errorCheck = () => {
+      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
+        TerrainCLI.error(
+          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+        );
+      }
+    };
+
+    // Attempt to execute command while backtracking through file tree.
+    await runCommand(
+      execPath,
+      command,
+      errorCheck,
+    );
   }
 }

--- a/src/commands/contract/store.ts
+++ b/src/commands/contract/store.ts
@@ -1,9 +1,13 @@
 import { Command, flags } from '@oclif/command';
 import { LCDClient } from '@terra-money/terra.js';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { loadConfig, loadConnections } from '../../config';
 import { storeCode } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
 import * as flag from '../../lib/flag';
+import TerrainCLI from '../../TerrainCLI';
+import runCommand from '../../lib/runCommand';
 
 export default class CodeStore extends Command {
   static description = 'Store code on chain.';
@@ -21,27 +25,49 @@ export default class CodeStore extends Command {
   async run() {
     const { args, flags } = this.parse(CodeStore);
 
-    const connections = loadConnections(flags['config-path']);
-    const config = loadConfig(flags['config-path']);
-    const conf = config(flags.network, args.contract);
+    // Command execution path.
+    const execPath = flags['config-path'];
 
-    const lcd = new LCDClient(connections(flags.network));
-    const signer = await getSigner({
-      network: flags.network,
-      signerId: flags.signer,
-      keysPath: flags['keys-path'],
-      lcd,
-    });
+    // Command to be performed.
+    const command = async () => {
+      const connections = loadConnections(flags['config-path']);
+      const config = loadConfig(flags['config-path']);
+      const conf = config(flags.network, args.contract);
 
-    await storeCode({
-      conf,
-      noRebuild: flags['no-rebuild'],
-      contract: args.contract,
-      signer,
-      network: flags.network,
-      refsPath: flags['refs-path'],
-      lcd,
-      codeId: flags['code-id'],
-    });
+      const lcd = new LCDClient(connections(flags.network));
+      const signer = await getSigner({
+        network: flags.network,
+        signerId: flags.signer,
+        keysPath: flags['keys-path'],
+        lcd,
+      });
+
+      await storeCode({
+        conf,
+        noRebuild: flags['no-rebuild'],
+        contract: args.contract,
+        signer,
+        network: flags.network,
+        refsPath: flags['refs-path'],
+        lcd,
+        codeId: flags['code-id'],
+      });
+    };
+
+    // Error check to be performed upon each backtrack iteration.
+    const errorCheck = () => {
+      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
+        TerrainCLI.error(
+          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+        );
+      }
+    };
+
+    // Attempt to execute command while backtracking through file tree.
+    await runCommand(
+      execPath,
+      command,
+      errorCheck,
+    );
   }
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -47,7 +47,7 @@ export default class Test extends Command {
 
     // Error check to be performed upon each backtrack iteration.
     const errorCheck = () => {
-      if (existsSync('contracts/') && !existsSync(execPath)) {
+      if (existsSync('contracts') && !existsSync(execPath)) {
         TerrainCLI.error(
           `Contract '${args['contract-name']}' not available in 'contracts/' directory.`,
         );

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -231,7 +231,13 @@ export const instantiate = async ({
 }: InstantiateParams) => {
   const { instantiation } = conf;
 
-  const actualCodeId = codeId || loadRefs(refsPath)[network][contract].codeId;
+  // Ensure contract refs are available in refs.terrain.json.
+  const refs = loadRefs(refsPath);
+  if (!(network in refs) || !(contract in refs[network])) {
+    TerrainCLI.error(`Contract '${contract}' has not been deployed on the '${network}' network.`);
+  }
+
+  const actualCodeId = codeId || refs[network][contract].codeId;
 
   cli.action.start(
     `instantiating contract with msg: ${JSON.stringify(

--- a/src/lib/runCommand.ts
+++ b/src/lib/runCommand.ts
@@ -25,7 +25,7 @@ async function runCommand(execPath: string, command: () => void, errorCheck: () 
   // If terrainAppRootPath not found after stepping back 4 directories,
   // tell user to run command in a terrain project directory.
   return TerrainCLI.warning(
-    'Please ensure that you are in a terrain project directory.',
+    `Command execute path ${execPath} not found. Please ensure that you are in a terrain project directory.`,
   );
 }
 

--- a/src/lib/runCommand.ts
+++ b/src/lib/runCommand.ts
@@ -25,7 +25,7 @@ async function runCommand(execPath: string, command: () => void, errorCheck: () 
   // If terrainAppRootPath not found after stepping back 4 directories,
   // tell user to run command in a terrain project directory.
   return TerrainCLI.warning(
-    `Command execute path ${execPath} not found. Please ensure that you are in a terrain project directory.`,
+    `Command execution path ${execPath} not found. Please ensure that you are in a terrain project directory.`,
   );
 }
 


### PR DESCRIPTION
Run the following commands anywhere inside a terrain app:
terrain contract:build
terrain contract:optimize
terrain contract:store
terrain contract:instantiate

Error handling inside of the `instantiate` function to do with a user attempting to instantiate a contract that is not yet deployed on a specified network.

Added execution path in warning at the end of `runCommand`.  The path may be useful to the user just in case a file or directory may have been accidentally moved, renamed, or deleted.