### PR TITLE
feat: run main commands anywhere

### DIFF
--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -1,9 +1,12 @@
 import { Command } from '@oclif/command';
-import * as path from 'path';
-import * as repl from 'repl';
+import { join, resolve } from 'path';
+import { existsSync } from 'fs';
+import { start } from 'repl';
 import * as terrajs from '@terra-money/terra.js';
 import { getEnv } from '../lib/env';
 import { signer, network, terrainPaths } from '../lib/flag';
+import TerrainCLI from '../TerrainCLI';
+import runCommand from '../lib/runCommand';
 
 // Needed for Terrain to be able to require typescript modules.
 require('ts-node').register({
@@ -26,51 +29,72 @@ export default class Console extends Command {
 
   async run() {
     const { flags } = this.parse(Console);
-    const fromCwd = (p: string) => path.join(process.cwd(), p);
 
-    const env = getEnv(
-      fromCwd(flags['config-path']),
-      fromCwd(flags['keys-path']),
-      fromCwd(flags['refs-path']),
-      flags.network,
-      flags.signer,
+    // Command execution path.
+    const execPath = 'lib';
+
+    // Command to be performed.
+    const command = async () => {
+      const env = getEnv(
+        join(process.cwd(), flags['config-path']),
+        join(process.cwd(), flags['keys-path']),
+        join(process.cwd(), flags['refs-path']),
+        flags.network,
+        flags.signer,
+      );
+
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      let Lib = await import(join(process.cwd(), 'lib'));
+
+      let libInstance;
+
+      // Detect if a default export exists and use that.
+      if (Lib?.default) {
+        Lib = Lib.default;
+      }
+
+      // Need the new keyword if Lib is a class.
+      if (typeof Lib === 'function' && Lib.prototype?.constructor) {
+        libInstance = new Lib(env);
+      } else {
+        libInstance = Lib(env);
+      }
+
+      // for repl server
+      const {
+        config, refs, wallets, client,
+      } = env;
+
+      const r = start({ prompt: 'terrain > ', useColors: true });
+
+      const def = (name: string, value: any) => Object.defineProperty(r.context, name, {
+        configurable: false,
+        enumerable: true,
+        value,
+      });
+
+      def('config', config);
+      def('refs', refs);
+      def('wallets', wallets);
+      def('client', client);
+      def('terrajs', terrajs);
+      def('lib', libInstance);
+    };
+
+    // Error check to be performed upon each backtrack iteration.
+    const errorCheck = () => {
+      if (existsSync('contracts') && !existsSync(execPath)) {
+        TerrainCLI.error(
+          `Execution directory '${execPath}' not available.`,
+        );
+      }
+    };
+
+    // Attempt to execute command while backtracking through file tree.
+    await runCommand(
+      execPath,
+      command,
+      errorCheck,
     );
-
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    let Lib = require(path.join(process.cwd(), 'lib'));
-
-    let libInstance;
-
-    // Detect if a default export exists and use that.
-    if (Lib?.default) {
-      Lib = Lib.default;
-    }
-
-    // Need the new keyword if Lib is a class.
-    if (typeof Lib === 'function' && Lib.prototype?.constructor) {
-      libInstance = new Lib(env);
-    } else {
-      libInstance = Lib(env);
-    }
-
-    // for repl server
-    const {
-      config, refs, wallets, client,
-    } = env;
-
-    const r = repl.start({ prompt: 'terrain > ', useColors: true });
-
-    const def = (name: string, value: any) => Object.defineProperty(r.context, name, {
-      configurable: false,
-      enumerable: true,
-      value,
-    });
-
-    def('config', config);
-    def('refs', refs);
-    def('wallets', wallets);
-    def('client', client);
-    def('terrajs', terrajs);
-    def('lib', libInstance);
   }
 }

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -1,5 +1,5 @@
 import { Command } from '@oclif/command';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { existsSync } from 'fs';
 import { start } from 'repl';
 import * as terrajs from '@terra-money/terra.js';

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,9 +1,13 @@
 import { Command, flags } from '@oclif/command';
 import { LCDClient } from '@terra-money/terra.js';
+import { join } from 'path';
+import { existsSync } from 'fs';
 import { loadConfig, loadConnections, loadGlobalConfig } from '../config';
 import { instantiate, storeCode } from '../lib/deployment';
 import { getSigner } from '../lib/signer';
 import * as flag from '../lib/flag';
+import TerrainCLI from '../TerrainCLI';
+import runCommand from '../lib/runCommand';
 
 export default class Deploy extends Command {
   static description = 'Build wasm bytecode, store code on chain and instantiate.';
@@ -28,82 +32,104 @@ export default class Deploy extends Command {
   async run() {
     const { args, flags } = this.parse(Deploy);
 
-    const connections = loadConnections(flags['config-path']);
-    const config = loadConfig(flags['config-path']);
-    const globalConfig = loadGlobalConfig(flags['config-path']);
-    const conf = config(flags.network, args.contract);
+    // Command execution path.
+    const execPath = 'config.terrain.json';
 
-    const lcd = new LCDClient(connections(flags.network));
-    const signer = await getSigner({
-      network: flags.network,
-      signerId: flags.signer,
-      keysPath: flags['keys-path'],
-      lcd,
-    });
+    // Command to be performed.
+    const command = async () => {
+      const connections = loadConnections(flags['config-path']);
+      const config = loadConfig(flags['config-path']);
+      const globalConfig = loadGlobalConfig(flags['config-path']);
+      const conf = config(flags.network, args.contract);
 
-    if (conf.deployTask) {
-      await this.config.runCommand('task:run', [
-        conf.deployTask,
-        '--signer',
-        flags.signer,
-        '--network',
-        flags.network,
-        '--refs-path',
-        flags['refs-path'],
-        '--config-path',
-        flags['config-path'],
-        '--keys-path',
-        flags['keys-path'],
-      ]);
-    } else {
-      // Store sequence to manually increment after code is stored.
-      const sequence = await signer.sequence();
-
-      const codeId = await storeCode({
-        lcd,
-        conf,
-        signer,
-        noRebuild: flags['no-rebuild'],
-        contract: args.contract,
+      const lcd = new LCDClient(connections(flags.network));
+      const signer = await getSigner({
         network: flags.network,
-        refsPath: flags['refs-path'],
-        useCargoWorkspace: globalConfig.useCargoWorkspace,
-      });
-
-      // pause for account sequence to update.
-      // eslint-disable-next-line no-promise-executor-return
-      await new Promise((r) => setTimeout(r, 1000));
-
-      const admin = flags['admin-address']
-        ? flags['admin-address']
-        : signer.key.accAddress;
-
-      await instantiate({
-        conf,
-        signer,
-        admin,
-        sequence: 1 + sequence,
-        contract: args.contract,
-        codeId,
-        network: flags.network,
-        instanceId: flags['instance-id'],
-        refsPath: flags['refs-path'],
+        signerId: flags.signer,
+        keysPath: flags['keys-path'],
         lcd,
       });
-    }
 
-    await this.config.runCommand('contract:generateClient', [
-      args.contract,
-      '--build-schema',
-    ]);
+      if (conf.deployTask) {
+        await this.config.runCommand('task:run', [
+          conf.deployTask,
+          '--signer',
+          flags.signer,
+          '--network',
+          flags.network,
+          '--refs-path',
+          flags['refs-path'],
+          '--config-path',
+          flags['config-path'],
+          '--keys-path',
+          flags['keys-path'],
+        ]);
+      } else {
+        // Store sequence to manually increment after code is stored.
+        const sequence = await signer.sequence();
 
-    if (!flags['no-sync']) {
-      await this.config.runCommand('sync-refs', [
-        '--refs-path',
-        flags['refs-path'],
-        '--dest',
-        flags['frontend-refs-path'],
+        const codeId = await storeCode({
+          lcd,
+          conf,
+          signer,
+          noRebuild: flags['no-rebuild'],
+          contract: args.contract,
+          network: flags.network,
+          refsPath: flags['refs-path'],
+          useCargoWorkspace: globalConfig.useCargoWorkspace,
+        });
+
+        // pause for account sequence to update.
+        // eslint-disable-next-line no-promise-executor-return
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const admin = flags['admin-address']
+          ? flags['admin-address']
+          : signer.key.accAddress;
+
+        await instantiate({
+          conf,
+          signer,
+          admin,
+          sequence: 1 + sequence,
+          contract: args.contract,
+          codeId,
+          network: flags.network,
+          instanceId: flags['instance-id'],
+          refsPath: flags['refs-path'],
+          lcd,
+        });
+      }
+
+      await this.config.runCommand('contract:generateClient', [
+        args.contract,
+        '--build-schema',
       ]);
-    }
+
+      if (!flags['no-sync']) {
+        await this.config.runCommand('sync-refs', [
+          '--refs-path',
+          flags['refs-path'],
+          '--dest',
+          flags['frontend-refs-path'],
+        ]);
+      }
+    };
+
+    // Error check to be performed upon each backtrack iteration.
+    const errorCheck = () => {
+      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
+        TerrainCLI.error(
+          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+        );
+      }
+    };
+
+    // Attempt to execute command while backtracking through file tree.
+    await runCommand(
+      execPath,
+      command,
+      errorCheck,
+    );
   }
 }

--- a/src/commands/sync-refs.ts
+++ b/src/commands/sync-refs.ts
@@ -1,9 +1,11 @@
 import { Command } from '@oclif/command';
 import * as path from 'path';
 import { cli } from 'cli-ux';
+import { existsSync } from 'fs';
 import * as fs from 'fs-extra';
 import { refsPath, frontendRefsPath } from '../lib/flag';
 import TerrainCLI from '../TerrainCLI';
+import runCommand from '../lib/runCommand';
 
 export default class SyncRefs extends Command {
   static description = 'Sync configuration with frontend app.';
@@ -16,22 +18,40 @@ export default class SyncRefs extends Command {
   async run() {
     const { flags } = this.parse(SyncRefs);
 
-    if (!fs.pathExistsSync(flags.dest)) {
-      TerrainCLI.error(`Failed to sync refs. Destination directory '${flags.dest}' not found.`);
-    }
+    // Command execution path.
+    const execPath = flags.dest;
 
-    // Append "refs.terrain.json" to flags.dest path if file unavailable.
-    // The fs.copyFileSync command requires the full file path.
-    const destFullPath = flags.dest.endsWith('refs.terrain.json')
-      ? flags.dest
-      : path.join(flags.dest, 'refs.terrain.json');
+    // Command to be performed.
+    const command = async () => {
+      // Append "refs.terrain.json" to flags.dest path if file unavailable.
+      // The fs.copyFileSync command requires the full file path.
+      const destFullPath = flags.dest.endsWith('refs.terrain.json')
+        ? flags.dest
+        : path.join(flags.dest, 'refs.terrain.json');
 
-    cli.action.start(
-      `Syncing refs from '${flags['refs-path']}' to '${destFullPath}'`,
+      cli.action.start(
+        `Syncing refs from '${flags['refs-path']}' to '${destFullPath}'`,
+      );
+
+      fs.copyFileSync(flags['refs-path'], destFullPath);
+
+      cli.action.stop();
+    };
+
+    // Error check to be performed upon each backtrack iteration.
+    const errorCheck = () => {
+      if (existsSync(execPath) && !existsSync('refs.terrain.json')) {
+        TerrainCLI.error(
+          'refs.terrain.json file not available in project root directory.',
+        );
+      }
+    };
+
+    // Attempt to execute command while backtracking through file tree.
+    await runCommand(
+      execPath,
+      command,
+      errorCheck,
     );
-
-    fs.copyFileSync(flags['refs-path'], destFullPath);
-
-    cli.action.stop();
   }
 }

--- a/src/lib/signer.ts
+++ b/src/lib/signer.ts
@@ -24,9 +24,9 @@ export const getSigner = async ({
     // Attempt to request sequence from LocalTerra.
     // Alert user if LocalTerra request fails.
     try {
-      cli.log(`Using pre-baked '${signerId}' wallet on LocalTerra as signer...`);
       const signer = localterra.wallets[signerId as keyof typeof localterra.wallets];
       await signer.sequence();
+      cli.log(`Using pre-baked '${signerId}' wallet on LocalTerra as signer...`);
       return signer;
     } catch {
       TerrainCLI.error('LocalTerra is currently not running.');


### PR DESCRIPTION
Run the following Terrain commands in any Terrain project subdirectory:
`terrain console`
`terrain deploy`
`terrain sync-refs`

Note:
`terrain test` has already been implemented in a prior PR.
`terrain new` is already a universal command!