### PR TITLE
feat: run contract commands anywhere 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,8 +553,8 @@ USAGE
 
 FLAGS
   --build-schema
-  --dest=<value>      [default: ./frontend/src/contract]
-  --lib-path=<value>  [default: ./lib] location to place the generated client
+  --dest=<value>      [default: frontend/src/contract]
+  --lib-path=<value>  [default: lib] location to place the generated client
 
 DESCRIPTION
   Generate a Wallet Provider or Terra.js compatible TypeScript client.
@@ -597,12 +597,12 @@ USAGE
 
 FLAGS
   --code-id=<value>      target code id for migration
-  --config-path=<value>  [default: ./config.terrain.json]
+  --config-path=<value>  [default: config.terrain.json]
   --instance-id=<value>  [default: default]
-  --keys-path=<value>    [default: ./keys.terrain.js]
+  --keys-path=<value>    [default: keys.terrain.js]
   --network=<value>      [default: localterra]
   --no-rebuild           deploy the wasm bytecode as is.
-  --refs-path=<value>    [default: ./refs.terrain.json]
+  --refs-path=<value>    [default: refs.terrain.json]
   --signer=<value>       [default: test1]
 
 DESCRIPTION
@@ -621,7 +621,7 @@ USAGE
 
 FLAGS
   --authors=<value>  [default: Terra Money <core@terra.money>]
-  --path=<value>     [default: ./contracts] path to keep the contracts
+  --path=<value>     [default: contracts] path to keep the contracts
   --version=<value>  [default: 1.0-beta6]
 
 DESCRIPTION
@@ -688,11 +688,11 @@ USAGE
     [--refs-path <value>] [--keys-path <value>] [--instance-id <value>]
 
 FLAGS
-  --config-path=<value>  [default: ./config.terrain.json]
+  --config-path=<value>  [default: config.terrain.json]
   --instance-id=<value>  [default: default]
-  --keys-path=<value>    [default: ./keys.terrain.js]
+  --keys-path=<value>    [default: keys.terrain.js]
   --network=<value>      [default: localterra] network to deploy to from config.terrain.json
-  --refs-path=<value>    [default: ./refs.terrain.json]
+  --refs-path=<value>    [default: refs.terrain.json]
   --signer=<value>       [default: test1]
 
 DESCRIPTION

--- a/src/commands/contract/migrate.ts
+++ b/src/commands/contract/migrate.ts
@@ -1,9 +1,13 @@
 import { Command, flags } from '@oclif/command';
 import { LCDClient } from '@terra-money/terra.js';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { loadConfig, loadConnections } from '../../config';
 import { migrate, storeCode } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
 import * as flag from '../../lib/flag';
+import TerrainCLI from '../../TerrainCLI';
+import runCommand from '../../lib/runCommand';
 
 export default class ContractMigrate extends Command {
   static description = 'Migrate the contract.';
@@ -12,9 +16,9 @@ export default class ContractMigrate extends Command {
     signer: flag.signer,
     'no-rebuild': flag.noRebuild,
     network: flags.string({ default: 'localterra' }),
-    'config-path': flags.string({ default: './config.terrain.json' }),
-    'refs-path': flags.string({ default: './refs.terrain.json' }),
-    'keys-path': flags.string({ default: './keys.terrain.js' }),
+    'config-path': flags.string({ default: 'config.terrain.json' }),
+    'refs-path': flags.string({ default: 'refs.terrain.json' }),
+    'keys-path': flags.string({ default: 'keys.terrain.js' }),
     'instance-id': flags.string({ default: 'default' }),
     'code-id': flags.integer({
       description:
@@ -27,37 +31,59 @@ export default class ContractMigrate extends Command {
   async run() {
     const { args, flags } = this.parse(ContractMigrate);
 
-    const connections = loadConnections(flags['config-path']);
-    const config = loadConfig(flags['config-path']);
-    const conf = config(flags.network, args.contract);
+    // Command execution path.
+    const execPath = flags['config-path'];
 
-    const lcd = new LCDClient(connections(flags.network));
-    const signer = await getSigner({
-      network: flags.network,
-      signerId: flags.signer,
-      keysPath: flags['keys-path'],
-      lcd,
-    });
+    // Command to be performed.
+    const command = async () => {
+      const connections = loadConnections(flags['config-path']);
+      const config = loadConfig(flags['config-path']);
+      const conf = config(flags.network, args.contract);
 
-    const codeId = await storeCode({
-      conf,
-      noRebuild: flags['no-rebuild'],
-      contract: args.contract,
-      signer,
-      network: flags.network,
-      refsPath: flags['refs-path'],
-      lcd,
-    });
+      const lcd = new LCDClient(connections(flags.network));
+      const signer = await getSigner({
+        network: flags.network,
+        signerId: flags.signer,
+        keysPath: flags['keys-path'],
+        lcd,
+      });
 
-    migrate({
-      conf,
-      signer,
-      contract: args.contract,
-      codeId,
-      network: flags.network,
-      instanceId: flags['instance-id'],
-      refsPath: flags['refs-path'],
-      lcd,
-    });
+      const codeId = await storeCode({
+        conf,
+        noRebuild: flags['no-rebuild'],
+        contract: args.contract,
+        signer,
+        network: flags.network,
+        refsPath: flags['refs-path'],
+        lcd,
+      });
+
+      migrate({
+        conf,
+        signer,
+        contract: args.contract,
+        codeId,
+        network: flags.network,
+        instanceId: flags['instance-id'],
+        refsPath: flags['refs-path'],
+        lcd,
+      });
+    };
+
+    // Error check to be performed upon each backtrack iteration.
+    const errorCheck = () => {
+      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
+        TerrainCLI.error(
+          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+        );
+      }
+    };
+
+    // Attempt to execute command while backtracking through file tree.
+    await runCommand(
+      execPath,
+      command,
+      errorCheck,
+    );
   }
 }


### PR DESCRIPTION
Run the following Terrain commands in any Terrain project subdirectory:

`terrain contract:generateClient`
`terrain contract:migrate`
`terrain contract:new`
`terrain contract:updateAdmin`

Note:

The following commands have already been updated in the original `feat: run contract commands anywhere` PR.

`terrain contract:build`
`terrain contract:optimize`
`terrain contract:store`
`terrain contract:instantiate`