### PR TITLE
style: TerrainCLI

### DIFF
--- a/src/TerrainCLI.ts
+++ b/src/TerrainCLI.ts
@@ -2,82 +2,70 @@ import chalk, { Chalk } from 'chalk';
 import cli from 'cli-ux';
 import boxen from 'boxen';
 import semver from 'semver';
+import dedent from 'dedent';
 
 /** TerrainCLI offers default log styling for terrain commands. */
 class TerrainCLI {
   prefix: string;
 
-  logStyle: Chalk;
+  anykeyStyle: Chalk;
 
   successStyle: Chalk;
-
-  warningStyle: Chalk;
 
   alertStyle: Chalk;
 
   errorStyle: Chalk;
 
-  anykeyStyle: Chalk;
+  variableStyle: Chalk;
 
   constructor(
     prefix: string,
-    logStyle: Chalk,
+    anykeyStyle: Chalk,
     successStyle: Chalk,
-    warningStyle: Chalk,
     alertStyle: Chalk,
     errorStyle: Chalk,
-    anykeyStyle: Chalk,
+    variableStyle: Chalk,
   ) {
     this.prefix = prefix;
-    this.logStyle = logStyle;
+    this.anykeyStyle = anykeyStyle;
     this.successStyle = successStyle;
-    this.warningStyle = warningStyle;
     this.alertStyle = alertStyle;
     this.errorStyle = errorStyle;
-    this.anykeyStyle = anykeyStyle;
+    this.variableStyle = variableStyle;
   }
 
-  // TerrainCLI.log(logMsg) styling.
-  log(logMsg = '') {
-    cli.log(
-      `\n${this.prefix} ${this.logStyle(logMsg)}\n`,
+  // Message box styling.
+  messageBox(
+    msg: string,
+    msgStyle: Chalk,
+    title: string,
+    emoji: string,
+    msgBoxWidth = 46,
+    variableStyle = this.variableStyle,
+  ) {
+    // Regex replace for text wrapping.
+    const textWrapMsg = msg.replace(
+      new RegExp(`(?![^\\n]{1,${msgBoxWidth}}$)([^\\n]{1,${msgBoxWidth}})\\s`, 'g'),
+      '$1\n',
     );
-  }
 
-  // TerrainCLI.success(successMsg) styling.
-  success(successMsg = '') {
-    cli.log(
-      `\n${this.prefix} ${this.successStyle(successMsg)}\n`,
+    // Replace variables, surrounded by single quotes, by the stylized variable.
+    const variableRegex = /"(.+)"/g;
+    const varHighlightMsg = textWrapMsg.replace(
+      variableRegex,
+      variableStyle('$1'),
     );
-  }
 
-  // TerrainCLI.warning(warningMsg) styling.
-  warning(warningMsg = '') {
-    cli.log(
-      `\n${this.prefix} ${this.warningStyle(`Warning: ${warningMsg}`)}\n`,
-    );
-  }
-
-  // TerrainCLI.alert(alertMsg, title, maxWidth) styling
-  alert(alertMsg = '', title = 'Hey! 👋', maxWidth = 36) {
-    cli.log(
-      this.alertStyle(
-        boxen(
-          alertMsg.replace(new RegExp(`(?![^\\n]{1,${maxWidth}}$)([^\\n]{1,${maxWidth}})\\s`, 'g'), '$1\n'),
-          {
-            title, titleAlignment: 'center', padding: 1, margin: 1,
-          },
-        ),
-      ),
-    );
-  }
-
-  // TerrainCLI.error(errorMsg) styling.
-  error(errorMsg = '') {
-    cli.log(
-      `\n${this.prefix} ${this.errorStyle(`Error: ${errorMsg}`)}\n`,
-    );
-    process.exit();
+    // Return stylized string inside of 'boxen' object for display in terminal.
+    return msgStyle(boxen(
+      varHighlightMsg,
+      {
+        title: chalk`{bold ${emoji} ${title}}`,
+        titleAlignment: 'left',
+        padding: 1,
+        margin: 1,
+      },
+    ));
   }
 
   // await TerrainCLI.anykey(anykeyMsg) styling.
@@ -85,18 +73,45 @@ class TerrainCLI {
     await cli.anykey(`\n${this.prefix} ${this.anykeyStyle(`${anykeyMsg}`)}`);
   }
 
+  // TerrainCLI.success(successMsg) styling.
+  success(successMsg = '', title = '', emoji = '✅') {
+    cli.log(this.messageBox(successMsg, this.successStyle, title, emoji));
+  }
+
+  // TerrainCLI.error(errorMsg) styling.
+  error(errorMsg = '', title = '', emoji = '🚨') {
+    cli.log(this.messageBox(errorMsg, this.errorStyle, title, emoji, 46, chalk.green));
+    process.exit();
+  }
+
+  // TerrainCLI.alert(alertMsg, title, maxWidth) styling
+  alert(alertMsg = '', title = '', emoji = '👋') {
+    cli.log(this.messageBox(alertMsg, this.alertStyle, title, emoji));
+  }
+
   // TerrainCLI.nodeVersionCheck() styling.
   nodeVersionCheck() {
     if (!semver.satisfies(process.version, '^16')) {
-      this.alert(`
-Terrain requires Node version 16!\n
-Please switch your version of Node before running Terrain commands.\n
-If you are utilizing nvm, simply utilize the following command:\n
-nvm use 16
-      `, '🚨 Incompatible Node Version 🚨');
+      this.error(
+        dedent`
+          Terrain requires "Node version 16"!\n
+          Please switch your version of Node before running Terrain commands.\n
+          If you are utilizing nvm, simply utilize the following command:\n
+          "nvm use 16"
+        `,
+        'Incompatible Node Version',
+        '🚨',
+      );
       process.exit();
     }
   }
 }
 
-export default new TerrainCLI(chalk.yellow('>'), chalk.white, chalk.green, chalk.hex('#FFA500'), chalk.hex('#CB48E8'), chalk.red, chalk.cyan);
+export default new TerrainCLI(
+  '👉',
+  chalk.cyan,
+  chalk.green,
+  chalk.blue,
+  chalk.yellow,
+  chalk.yellow,
+);

--- a/src/commands/contract/build.ts
+++ b/src/commands/contract/build.ts
@@ -32,7 +32,8 @@ export default class Build extends Command {
     const errorCheck = () => {
       if (existsSync('contracts') && !existsSync(execPath)) {
         TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+          `Contract "${args.contract}" not available in "contracts/" directory.`,
+          'Contract Unavailable',
         );
       }
     };

--- a/src/commands/contract/generateClient.ts
+++ b/src/commands/contract/generateClient.ts
@@ -45,8 +45,8 @@ export default class GenerateClient extends Command {
       'syncing clients to frontend',
     );
 
-    if (!fs.pathExistsSync('./frontend')) {
-      TerrainCLI.warning('no frontend directory found, not syncing refs');
+    if (!fs.pathExistsSync('frontend')) {
+      TerrainCLI.error('The "frontend/" directory was not found.', 'Failed to Sync Refs');
       cli.action.stop();
       return;
     }

--- a/src/commands/contract/instantiate.ts
+++ b/src/commands/contract/instantiate.ts
@@ -64,7 +64,8 @@ export default class ContractInstantiate extends Command {
     const errorCheck = () => {
       if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
         TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+          `Contract "${args.contract}" not available in "contracts/" directory.`,
+          'Contract Unavailable',
         );
       }
     };

--- a/src/commands/contract/optimize.ts
+++ b/src/commands/contract/optimize.ts
@@ -36,7 +36,8 @@ export default class Optimize extends Command {
     const errorCheck = () => {
       if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
         TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+          `Contract "${args.contract}" not available in "contracts/" directory.`,
+          'Contract Unavailable',
         );
       }
     };

--- a/src/commands/contract/store.ts
+++ b/src/commands/contract/store.ts
@@ -58,7 +58,8 @@ export default class CodeStore extends Command {
     const errorCheck = () => {
       if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
         TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
+          `Contract "${args.contract}" not available in "contracts/" directory.`,
+          'Contract Unavailable',
         );
       }
     };

--- a/src/commands/sync-refs.ts
+++ b/src/commands/sync-refs.ts
@@ -17,7 +17,7 @@ export default class SyncRefs extends Command {
     const { flags } = this.parse(SyncRefs);
 
     if (!fs.pathExistsSync(flags.dest)) {
-      TerrainCLI.error(`Failed to sync refs. Destination directory '${flags.dest}' not found.`);
+      TerrainCLI.error(`Destination directory "${flags.dest}" not found.`, 'Failed to Sync Refs');
     }
 
     // Append "refs.terrain.json" to flags.dest path if file unavailable.

--- a/src/commands/task/new.ts
+++ b/src/commands/task/new.ts
@@ -40,7 +40,10 @@ export default class TaskNew extends Command {
     // Error check to be performed upon each backtrack iteration.
     const errorCheck = () => {
       if (existsSync(newTaskPath)) {
-        TerrainCLI.error(`A task with the name ${args.task} already exists. Try using another name for the task.`);
+        TerrainCLI.error(
+          `A task with the name "${args.task}" already exists in the "tasks/" directory. Try using another name for the task.`,
+          'Task Available',
+        );
       }
     };
 

--- a/src/commands/task/run.ts
+++ b/src/commands/task/run.ts
@@ -91,7 +91,8 @@ export default class Run extends Command {
           });
         }
         TerrainCLI.error(
-          `Task '${args.task}' not available in 'tasks/' directory.`,
+          `Task "${args.task}" not available in "tasks/" directory.`,
+          'Task Not Found',
         );
       }
       return null;

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -49,7 +49,8 @@ export default class Test extends Command {
     const errorCheck = () => {
       if (existsSync('contracts') && !existsSync(execPath)) {
         TerrainCLI.error(
-          `Contract '${args['contract-name']}' not available in 'contracts/' directory.`,
+          `Contract "${args['contract-name']}" not available in "contracts/" directory.`,
+          'Contract Unavailable',
         );
       }
     };

--- a/src/commands/wallet/new.ts
+++ b/src/commands/wallet/new.ts
@@ -34,7 +34,10 @@ export default class WalletNew extends Command {
       this.exit(0);
     }
 
-    TerrainCLI.warning('Anyone who gains access to your seed phrase can access the contents of the corresponding wallet. Be cognizant of the fact that there is no recourse for theft of a seed phrase.');
+    TerrainCLI.error(
+      'Anyone who gains access to your seed phrase can access the contents of the corresponding wallet. Be cognizant of the fact that there is no recourse for theft of a seed phrase.',
+      'Private Key Warning',
+    );
 
     this.log('address:');
     this.log(mk.accAddress);

--- a/src/commands/wallet/new.ts
+++ b/src/commands/wallet/new.ts
@@ -34,16 +34,14 @@ export default class WalletNew extends Command {
       this.exit(0);
     }
 
-    TerrainCLI.error(
-      'Anyone who gains access to your seed phrase can access the contents of the corresponding wallet. Be cognizant of the fact that there is no recourse for theft of a seed phrase.',
-      'Private Key Warning',
-    );
-
     this.log('address:');
     this.log(mk.accAddress);
     this.log('mnemonic key:');
     this.log(mk.mnemonic);
 
-    this.exit(0);
+    TerrainCLI.error(
+      'Anyone who gains access to your seed phrase can access the contents of the corresponding wallet. Be cognizant of the fact that there is no recourse for theft of a seed phrase.',
+      'Private Key Warning',
+    );
   }
 }

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -26,6 +26,7 @@ import {
 } from '../config';
 import TerrainCLI from '../TerrainCLI';
 import useARM64 from './useARM64';
+import dedent from 'dedent';
 
 type BuildParams = {
   contract: string;
@@ -153,10 +154,9 @@ export const storeCode = async ({
   // Check if user is attempting to store ARM64 wasm binary on mainnet.
   // If so, reoptimize to default wasm binary to store on mainnet.
   if (storingARM64Mainnet) {
-    TerrainCLI.alert(`
-ARM64 wasm files should not be stored on mainnet.\n
-Rebuilding contract to deploy default wasm binary.
-    `, '🚨 ARM64 Wasm Detected 🚨');
+    TerrainCLI.error(dedent`
+ARM64 wasm files should not be stored on mainnet. Rebuilding contract to deploy default wasm binary.
+    `, 'ARM64 Wasm Detected');
 
     await optimize({ contract, useCargoWorkspace, network });
   }
@@ -234,7 +234,10 @@ export const instantiate = async ({
   // Ensure contract refs are available in refs.terrain.json.
   const refs = loadRefs(refsPath);
   if (!(network in refs) || !(contract in refs[network])) {
-    TerrainCLI.error(`Contract '${contract}' has not been deployed on the '${network}' network.`);
+    TerrainCLI.error(
+      `Contract "${contract}" has not been deployed on the "${network}" network.`,
+      'Contract Not Deployed',
+    );
   }
 
   const actualCodeId = codeId || refs[network][contract].codeId;

--- a/src/lib/runCommand.ts
+++ b/src/lib/runCommand.ts
@@ -24,8 +24,9 @@ async function runCommand(execPath: string, command: () => void, errorCheck: () 
 
   // If terrainAppRootPath not found after stepping back 4 directories,
   // tell user to run command in a terrain project directory.
-  return TerrainCLI.warning(
-    `Command execution path ${execPath} not found. Please ensure that you are in a terrain project directory.`,
+  return TerrainCLI.error(
+    `Command execution path "${execPath}" not found. Please ensure that you are in a terrain project directory.`,
+    'Execution Path Not Found',
   );
 }
 

--- a/src/lib/signer.ts
+++ b/src/lib/signer.ts
@@ -29,14 +29,20 @@ export const getSigner = async ({
       await signer.sequence();
       return signer;
     } catch {
-      TerrainCLI.error('LocalTerra is currently not running.');
+      TerrainCLI.error(
+        'LocalTerra is currently not running.',
+        'Network Unavailable',
+      );
     }
   }
   // If using testnet or mainnet, evaluate if key of provided signer
   // is available in keysPath. If so, return signer Wallet.
   const keys = loadKeys(path.join(process.cwd(), keysPath));
   if (!keys[signerId]) {
-    TerrainCLI.error(`The key corresponding to '${signerId}' does not exist in '${keysPath}'.`);
+    TerrainCLI.error(
+      `The key corresponding to "${signerId}" does not exist in "${keysPath}".`,
+      'Signer Not Found',
+    );
   }
   return new Wallet(lcd, keys[signerId]);
 };


### PR DESCRIPTION
Updating TerrainCLI styling to include stylized, boxed terminal messages.  TerrainCLI logs will now require the user to provide a message as well as a title for presentation.  Furthermore, the user can surround important information with double quotes so that it may be highlighted in a different color.  Example:

`TerrainCLI.error('Contract "${args.contract}" has not been deployed to the "${args.network}" network', 'Contract Not Deployed');`