### PR TITLE
feat: default error check

### DIFF
--- a/src/TerrainCLI.ts
+++ b/src/TerrainCLI.ts
@@ -50,7 +50,7 @@ class TerrainCLI {
     );
 
     // Replace variables, surrounded by double quotes, by the stylized variable.
-    const variableRegex = /"(.+)"/g;
+    const variableRegex = /"(.+?)"/g;
     const varHighlightMsg = textWrapMsg.replace(
       variableRegex,
       variableStyle('$1'),
@@ -100,7 +100,6 @@ class TerrainCLI {
           "nvm use 16"
         `,
         'Incompatible Node Version',
-        '🚨',
       );
       process.exit();
     }

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -85,7 +85,8 @@ export default class Console extends Command {
     const errorCheck = () => {
       if (existsSync('contracts') && !existsSync(execPath)) {
         TerrainCLI.error(
-          `Execution directory '${execPath}' not available.`,
+          `Execution directory "${execPath}" not available in root application path.`,
+          'Execution Path Not Found',
         );
       }
     };

--- a/src/commands/contract/build.ts
+++ b/src/commands/contract/build.ts
@@ -1,10 +1,9 @@
 import { Command } from '@oclif/command';
 import { join } from 'path';
-import { existsSync } from 'fs';
 import { build } from '../../lib/deployment';
 import * as flag from '../../lib/flag';
-import TerrainCLI from '../../TerrainCLI';
 import runCommand from '../../lib/runCommand';
+import defaultErrorCheck from '../../lib/defaultErrorCheck';
 
 export default class Build extends Command {
   static description = 'Build wasm bytecode.';
@@ -28,21 +27,11 @@ export default class Build extends Command {
       });
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(execPath)) {
-        TerrainCLI.error(
-          `Contract "${args.contract}" not available in "contracts/" directory.`,
-          'Contract Unavailable',
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args.contract),
     );
   }
 }

--- a/src/commands/contract/generateClient.ts
+++ b/src/commands/contract/generateClient.ts
@@ -2,11 +2,12 @@ import { Command, flags } from '@oclif/command';
 import { cli } from 'cli-ux';
 import { join } from 'path';
 import { execSync } from 'child_process';
-import { pathExistsSync, existsSync, copySync } from 'fs-extra';
+import { pathExistsSync, copySync } from 'fs-extra';
 import { pascal } from 'case';
 import TerrainCLI from '../../TerrainCLI';
 import runCommand from '../../lib/runCommand';
 import generateClient from '../../lib/generateClient';
+import defaultErrorCheck from '../../lib/defaultErrorCheck';
 
 export default class GenerateClient extends Command {
   static description = 'Generate a Wallet Provider or Terra.js compatible TypeScript client.';
@@ -56,7 +57,7 @@ export default class GenerateClient extends Command {
       );
 
       if (!pathExistsSync('frontend')) {
-        TerrainCLI.error('The "frontend/" directory was not found.', 'Failed to Sync Refs');
+        TerrainCLI.error('The "frontend" directory was not found.', 'Failed to Sync Refs');
         cli.action.stop();
         return;
       }
@@ -66,20 +67,11 @@ export default class GenerateClient extends Command {
       cli.action.stop();
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(execPath)) {
-        TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args.contract),
     );
   }
 }

--- a/src/commands/contract/instantiate.ts
+++ b/src/commands/contract/instantiate.ts
@@ -1,13 +1,11 @@
 import { Command, flags } from '@oclif/command';
 import { LCDClient } from '@terra-money/terra.js';
-import { join } from 'path';
-import { existsSync } from 'fs';
 import { loadConfig, loadConnections } from '../../config';
 import { instantiate } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
 import * as flag from '../../lib/flag';
-import TerrainCLI from '../../TerrainCLI';
 import runCommand from '../../lib/runCommand';
+import defaultErrorCheck from '../../lib/defaultErrorCheck';
 
 export default class ContractInstantiate extends Command {
   static description = 'Instantiate the contract.';
@@ -60,21 +58,11 @@ export default class ContractInstantiate extends Command {
       });
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
-        TerrainCLI.error(
-          `Contract "${args.contract}" not available in "contracts/" directory.`,
-          'Contract Unavailable',
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args.contract),
     );
   }
 }

--- a/src/commands/contract/migrate.ts
+++ b/src/commands/contract/migrate.ts
@@ -1,13 +1,11 @@
 import { Command, flags } from '@oclif/command';
 import { LCDClient } from '@terra-money/terra.js';
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { loadConfig, loadConnections } from '../../config';
 import { migrate, storeCode } from '../../lib/deployment';
 import { getSigner } from '../../lib/signer';
 import * as flag from '../../lib/flag';
-import TerrainCLI from '../../TerrainCLI';
 import runCommand from '../../lib/runCommand';
+import defaultErrorCheck from '../../lib/defaultErrorCheck';
 
 export default class ContractMigrate extends Command {
   static description = 'Migrate the contract.';
@@ -70,20 +68,11 @@ export default class ContractMigrate extends Command {
       });
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
-        TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args.contract),
     );
   }
 }

--- a/src/commands/contract/optimize.ts
+++ b/src/commands/contract/optimize.ts
@@ -1,11 +1,9 @@
 import { Command } from '@oclif/command';
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { optimize } from '../../lib/deployment';
 import { configPath } from '../../lib/flag';
 import { loadGlobalConfig } from '../../config';
-import TerrainCLI from '../../TerrainCLI';
 import runCommand from '../../lib/runCommand';
+import defaultErrorCheck from '../../lib/defaultErrorCheck';
 
 export default class Optimize extends Command {
   static description = 'Optimize wasm bytecode.';
@@ -32,21 +30,11 @@ export default class Optimize extends Command {
       });
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
-        TerrainCLI.error(
-          `Contract "${args.contract}" not available in "contracts/" directory.`,
-          'Contract Unavailable',
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args.contract),
     );
   }
 }

--- a/src/commands/contract/updateAdmin.ts
+++ b/src/commands/contract/updateAdmin.ts
@@ -2,12 +2,11 @@ import { Command, flags } from '@oclif/command';
 import * as YAML from 'yaml';
 import { LCDClient, MsgUpdateContractAdmin } from '@terra-money/terra.js';
 import { cli } from 'cli-ux';
-import { existsSync } from 'fs';
 import { loadConnections, loadRefs } from '../../config';
 import { getSigner } from '../../lib/signer';
 import * as flag from '../../lib/flag';
-import TerrainCLI from '../../TerrainCLI';
 import runCommand from '../../lib/runCommand';
+import defaultErrorCheck from '../../lib/defaultErrorCheck';
 
 export default class ContractUpdateAdmin extends Command {
   static description = 'Update the admin of a contract.';
@@ -72,20 +71,11 @@ export default class ContractUpdateAdmin extends Command {
       }
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(execPath)) {
-        TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args.contract),
     );
   }
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,13 +1,11 @@
 import { Command, flags } from '@oclif/command';
 import { LCDClient } from '@terra-money/terra.js';
-import { join } from 'path';
-import { existsSync } from 'fs';
 import { loadConfig, loadConnections, loadGlobalConfig } from '../config';
 import { instantiate, storeCode } from '../lib/deployment';
 import { getSigner } from '../lib/signer';
 import * as flag from '../lib/flag';
-import TerrainCLI from '../TerrainCLI';
 import runCommand from '../lib/runCommand';
+import defaultErrorCheck from '../lib/defaultErrorCheck';
 
 export default class Deploy extends Command {
   static description = 'Build wasm bytecode, store code on chain and instantiate.';
@@ -116,20 +114,11 @@ export default class Deploy extends Command {
       }
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(join('contracts', args.contract))) {
-        TerrainCLI.error(
-          `Contract '${args.contract}' not available in 'contracts/' directory.`,
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args.contract),
     );
   }
 }

--- a/src/commands/task/new.ts
+++ b/src/commands/task/new.ts
@@ -41,8 +41,8 @@ export default class TaskNew extends Command {
     const errorCheck = () => {
       if (existsSync(newTaskPath)) {
         TerrainCLI.error(
-          `A task with the name "${args.task}" already exists in the "tasks/" directory. Try using another name for the task.`,
-          'Task Available',
+          `A task with the name "${args.task}" already exists in the "tasks" directory. Try using another name for the task.`,
+          'Task Already Exists',
         );
       }
     };

--- a/src/commands/task/run.ts
+++ b/src/commands/task/run.ts
@@ -91,7 +91,7 @@ export default class Run extends Command {
           });
         }
         TerrainCLI.error(
-          `Task "${args.task}" not available in "tasks/" directory.`,
+          `Task "${args.task}" not available in "tasks" directory.`,
           'Task Not Found',
         );
       }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,9 +1,8 @@
 import { Command, flags } from '@oclif/command';
 import { execSync } from 'child_process';
 import { join } from 'path';
-import { existsSync } from 'fs';
 import runCommand from '../lib/runCommand';
-import TerrainCLI from '../TerrainCLI';
+import defaultErrorCheck from '../lib/defaultErrorCheck';
 
 /**
  * Runs unit tests for a contract directory.
@@ -45,21 +44,11 @@ export default class Test extends Command {
       );
     };
 
-    // Error check to be performed upon each backtrack iteration.
-    const errorCheck = () => {
-      if (existsSync('contracts') && !existsSync(execPath)) {
-        TerrainCLI.error(
-          `Contract "${args['contract-name']}" not available in "contracts/" directory.`,
-          'Contract Unavailable',
-        );
-      }
-    };
-
     // Attempt to execute command while backtracking through file tree.
     await runCommand(
       execPath,
       command,
-      errorCheck,
+      defaultErrorCheck(args['contract-name']),
     );
   }
 }

--- a/src/lib/defaultErrorCheck.ts
+++ b/src/lib/defaultErrorCheck.ts
@@ -1,0 +1,16 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import TerrainCLI from '../TerrainCLI';
+
+function defaultErrorCheck(contractName: string) {
+  return function errorCheck() {
+    if (existsSync('contracts') && !existsSync(join('contracts', contractName))) {
+      TerrainCLI.error(
+        `Contract "${contractName}" not available in "contracts" directory.`,
+        'Contract Not Found',
+      );
+    }
+  };
+}
+
+export default defaultErrorCheck;

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -236,7 +236,7 @@ export const instantiate = async ({
   if (!(network in refs) || !(contract in refs[network])) {
     TerrainCLI.error(
       `Contract "${contract}" has not been deployed on the "${network}" network.`,
-      'Contract Not Deployed',
+      'Contract Not Yet Deployed',
     );
   }
 

--- a/src/lib/runCommand.ts
+++ b/src/lib/runCommand.ts
@@ -2,7 +2,11 @@ import { existsSync } from 'fs';
 import * as path from 'path';
 import TerrainCLI from '../TerrainCLI';
 
-async function runCommand(execPath: string, command: () => void, errorCheck: () => void) {
+async function runCommand(
+  execPath: string,
+  command: () => void,
+  errorCheck: () => void,
+) {
   // Initialize terrainAppRootPath directory to current working directory.
   let terrainAppRootPath = process.cwd();
 


### PR DESCRIPTION
Created a defaultErrorCheck function which is imported to each file that uses `Contract Not Found` errors and replaced them.  Evaluated setting defaultErrorCheck as the default for errorCheck in the runCommand function, however, each command utilizes their own contract name, which will have to be passed to the function directly.

Updated TerrainCLI calls to adhere to updated styling functionality.

Updated variable highlighting regex to be non-greedy to allow for highlighting of multiple vars.