### PR TITLE
fix: surface npm errors

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -111,13 +111,13 @@ export default class New extends Command {
     // Install app dependencies.
     process.chdir(appDir);
     cli.action.start('  🏗  Installing app dependencies');
-    await execSync('npm i --silent', { stdio: 'inherit' });
+    await execSync('npm i --loglevel error', { stdio: ['ignore', 'ignore', 'inherit'] });
     cli.action.stop();
 
     // Install frontend dependencies.
-    cli.action.start('  🔧 Installing frontend dependencies');
     process.chdir(frontendDir);
-    await execSync('npm i --silent', { stdio: 'inherit' });
+    cli.action.start('  🔧 Installing frontend dependencies');
+    await execSync('npm i --loglevel error', { stdio: ['ignore', 'ignore', 'inherit'] });
     cli.action.stop();
 
     TerrainCLI.success(dedent`


### PR DESCRIPTION
Retaining silent npm logs and warnings while surfacing any errors that occur.

<img width="521" alt="image" src="https://user-images.githubusercontent.com/30275692/197577896-b6bede17-9803-4762-9318-5e5aa5108bfc.png">
