### PR TITLE
fix: cw-template version

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,12 +621,12 @@ Generate new contract.
 
 ```
 USAGE
-  $ terrain contract:new [NAME] [--path <value>] [--version <value>] [--authors <value>]
+  $ terrain contract:new [NAME] [--path <value>] [--commitHash <value>] [--authors <value>]
 
 FLAGS
-  --authors=<value>  [default: Terra Money <core@terra.money>]
-  --path=<value>     [default: contracts] path to keep the contracts
-  --version=<value>  [default: 1.0-beta6]
+  --authors=<value>     [default: Terra Money <core@terra.money>]
+  --commitHash=<value>  [default: 9fa5b9b38fca4f99239ac28be48a6e1f0a4d30c8]
+  --path=<value>        [default: contracts] path to keep the contracts
 
 DESCRIPTION
   Generate new contract.

--- a/src/commands/contract/new.ts
+++ b/src/commands/contract/new.ts
@@ -20,8 +20,8 @@ export default class CodeNew extends Command {
       description: 'path to keep the contracts',
       default: 'contracts',
     }),
-    version: flags.string({
-      default: '1.0-beta6',
+    commitHash: flags.string({
+      default: '9fa5b9b38fca4f99239ac28be48a6e1f0a4d30c8',
     }),
     authors: flags.string({
       default: 'Terra Money <core@terra.money>',
@@ -42,8 +42,8 @@ export default class CodeNew extends Command {
       cli.action.start('- contract');
 
       await TemplateScaffolding.from({
-        remoteUrl: `https://codeload.github.com/InterWasm/cw-template/zip/refs/tags/${flags.version}`,
-        subFolder: `cw-template-${flags.version}`,
+        remoteUrl: `https://www.github.com/CosmWasm/cw-template/archive/${flags.commitHash}.zip`,
+        subFolder: `cw-template-${flags.commitHash}`,
         localOptions: {
           folderUrl: join(process.cwd(), flags.path, args.name),
         },


### PR DESCRIPTION
Version `1.0-beta6` of the [CosmWasm/cw-template](https://github.com/CosmWasm/cw-template) throws an error when you attempt to deploy with Terrain.  The issue is with the setup of `CustomError` in the `src/error.rs` directory.  This PR pulls the template from the [9fa5b9b38fca4f99239ac28be48a6e1f0a4d30c8 commit hash](https://github.com/CosmWasm/cw-template/commit/9fa5b9b38fca4f99239ac28be48a6e1f0a4d30c8) which is directly after the [latest version release commit hash](https://github.com/CosmWasm/cw-template/commit/c771646bac6aed25741478984dc902f20d00881e).  This commit only contains the update to `CustomError` which allows Terrain to deploy the template contract without error.