### PR TITLE
fix: build schema flag removal

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -101,7 +101,6 @@ export default class Deploy extends Command {
 
       await this.config.runCommand('contract:generateClient', [
         args.contract,
-        '--build-schema',
       ]);
 
       if (!flags['no-sync']) {


### PR DESCRIPTION
The `--build-schema` flag was removed from the `terrain contract:generateClient` command as the `cargo schema` command is executed upon `terrain contract:build` command execution.  In this PR, I am removing this flag from being passed when calling the `generateClient` command from `deploy`.